### PR TITLE
Fix windows slowness

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -23,6 +23,7 @@ type applyConfig struct {
 }
 
 func newCmdApply(client *openapi.APIClient) *cobra.Command {
+	log.Trace("Running apply cmd generator")
 	config := applyConfig{
 		client: client,
 	}

--- a/cmd/iks.go
+++ b/cmd/iks.go
@@ -5,11 +5,11 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"os/user"
 	"path/filepath"
 	"time"
 
 	openapi "github.com/cgascoig/intersight-go-sdk/intersight"
+	homedir "github.com/mitchellh/go-homedir"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -144,8 +144,9 @@ func getCreateCommand(config iksConfig) *cobra.Command {
 	flags.String(vmInstanceTypeFlag, "", "Name of VM Instance Type Policy ")
 
 	var homeDir string = ""
-	if usr, err := user.Current(); err == nil {
-		homeDir = usr.HomeDir
+	homeDir, err := homedir.Dir()
+	if err != nil {
+		log.Fatalln(err)
 	}
 
 	flags.String(sshUserFlag, "iksadmin", "Name of user account to create on Kubernetes nodes for SSH access")

--- a/cmd/iks.go
+++ b/cmd/iks.go
@@ -22,6 +22,7 @@ type iksConfig struct {
 }
 
 func newCmdIKS(client *openapi.APIClient) *cobra.Command {
+	log.Trace("Running iks cmd generator")
 	config := iksConfig{
 		client: client,
 	}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	openapi "github.com/cgascoig/intersight-go-sdk/intersight"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -15,6 +16,7 @@ var (
 const ()
 
 func newCmdVersion(client *openapi.APIClient) *cobra.Command {
+	log.Trace("Running version cmd generator")
 	return &cobra.Command{
 		Use:               "version",
 		Run:               runCmdVersion,


### PR DESCRIPTION
Fix slow setup time on Windows - use go-homedir instead of os/user for finding SSH key default location

Some of #56 is likely due to this issue on Windows, not just DNS