### PR TITLE
fix support for objects with same name in multiple orgs

### DIFF
--- a/tests/apply.bats
+++ b/tests/apply.bats
@@ -29,26 +29,6 @@ TEST_SECTION="Apply"
     [ "${NTPSERVERS}" == "[\"1.1.1.1\",\"2.2.2.2\"]" ]
 }
 
-@test "${TEST_SECTION}: apply YAML file with duplicated NTP Policy name in different org" {
-    # Apply YAML with same NTP policy name but different org (also creates the org)
-    ./build/isctl ${ISCTL_OPTIONS} apply -f tests/data/test-duplicate-name-cross-orgs.yaml
-
-    # Get the Moid of new org
-    ORG_MOID=$(./build/isctl ${ISCTL_OPTIONS} get organization organization name isctl-bats-dup-test -o jsonpath=.Moid)
-    [ ! -z "${ORG_MOID}" ]
-
-    # Check if new policy in org was created successfully
-    NTP_MOID=$(./build/isctl ${ISCTL_OPTIONS} get ntp policy --filter "Name eq '${TEST_NAME}' and Organization/Moid eq '${ORG_MOID}'" -o 'jsonpath=$[*].Moid')
-    [ ! -z "${NTP_MOID}" ]
-    # ./build/isctl ${ISCTL_OPTIONS} get ntp policy --filter "Name eq '${TEST_NAME}' and Organization/Moid eq '${ORG_MOID}'" | grep "${TEST_NAME}"
-
-    # ./build/isctl 
-
-    run ./build/isctl ${ISCTL_OPTIONS} delete ntp policy moid ${NTP_MOID}
-    run ./build/isctl ${ISCTL_OPTIONS} delete organization organization moid ${ORG_MOID}
-}
-
-
 @test "${TEST_SECTION}: delete NTP policy" {
     ./build/isctl ${ISCTL_OPTIONS} delete ntp policy moid $(./build/isctl ${ISCTL_OPTIONS} get ntp policy --name "${TEST_NAME}" -o jsonpath='$.Moid')
     sleep 5

--- a/tests/data/test-duplicate-name-cross-orgs.yaml
+++ b/tests/data/test-duplicate-name-cross-orgs.yaml
@@ -1,11 +1,3 @@
-ClassId: organization.Organization
-ObjectType: organization.Organization
-Name: isctl-bats-dup-test
----
-ClassId: ntp.Policy
-ObjectType: ntp.Policy
-Name: isctl-bats-test
-Enabled: true
-NtpServers:
-  - 2.2.2.2
-Organization: isctl-bats-dup-test
+ClassId: iam.EndPointUser
+Organization: isctl-org-test
+Name: isctl-org-test

--- a/tests/orginization.bats
+++ b/tests/orginization.bats
@@ -1,0 +1,68 @@
+
+#this is the name used for created test objects. Must match the names in YAML files in tests/data/...
+TEST_NAME=isctl-org-test   
+
+TEST_SECTION="Organization"
+
+@test "${TEST_SECTION}: manually create duplicate endpointuser policies" {
+    echo "Creating test IAM endpointuser in default org"
+    ./build/isctl ${ISCTL_OPTIONS} create iam endpointuser --Name "${TEST_NAME}" --Organization "default"
+    echo "Creating test IAM endpointuser in test org"
+    ./build/isctl ${ISCTL_OPTIONS} create iam endpointuser --Name "${TEST_NAME}" --Organization "${TEST_NAME}"
+}
+
+# This test is disabled as it the API no longer allows NTP policies with the same name in different orgs
+# @test "${TEST_SECTION}: manually create duplicate ntp policies" {
+#     echo "Creating test NTP policy in default org"
+#     ./build/isctl ${ISCTL_OPTIONS} create ntp policy --Name "${TEST_NAME}" --Organization "default" --NtpServers 1.1.1.1
+
+#     echo "Creating test NTP policy in test org"
+#     ./build/isctl ${ISCTL_OPTIONS} create ntp policy --Name "${TEST_NAME}" --Organization "${TEST_NAME}" --NtpServers 1.1.1.1
+# }
+
+@test "${TEST_SECTION}: apply YAML file with duplicated endpointuser name in different org" {
+    # delete the endpointuser in test org if it exists
+    ORG_MOID=$(./build/isctl ${ISCTL_OPTIONS} get organization organization --name "${TEST_NAME}" -o jsonpath='$.Moid'|| echo "")
+    run ./build/isctl ${ISCTL_OPTIONS} delete iam endpointuser moid $(./build/isctl ${ISCTL_OPTIONS} get iam endpointuser --filter "Name eq '${TEST_NAME}' and Organization/Moid eq '${ORG_MOID}'" -o 'jsonpath=$[*].Moid'|| echo "")
+    
+    # Apply YAML with duplicate endpointuser in test org
+    ./build/isctl ${ISCTL_OPTIONS} apply -f tests/data/test-duplicate-name-cross-orgs.yaml
+
+    # Check if new endpointuser in test org was created successfully
+    EPU_MOID=$(./build/isctl ${ISCTL_OPTIONS} get iam endpointuser --filter "Name eq '${TEST_NAME}' and Organization/Moid eq '${ORG_MOID}'" -o 'jsonpath=$[*].Moid')
+    [ ! -z "${EPU_MOID}" ]
+}
+
+setup() {
+    load 'test_helper/bats-support/load' # this is required by bats-assert!
+    load 'test_helper/bats-assert/load'
+}
+
+setup_file() {
+    # # delete the test objects if they already exist. Don't check the exit code. 
+    teardown_file
+
+    echo "Creating test organization"
+    ./build/isctl ${ISCTL_OPTIONS} create organization organization --Name "${TEST_NAME}"
+}
+
+teardown_file() {
+    echo "Cleaning up objects"
+    # Delete the objects in default org
+    echo "Deleting objects in default org.."
+    run ./build/isctl ${ISCTL_OPTIONS} delete ntp policy moid $(./build/isctl ${ISCTL_OPTIONS} get ntp policy --name "${TEST_NAME}" -o jsonpath='$.Moid'|| echo "")
+    run ./build/isctl ${ISCTL_OPTIONS} delete iam endpointuser moid $(./build/isctl ${ISCTL_OPTIONS} get iam endpointuser --name "${TEST_NAME}" -o jsonpath='$.Moid'|| echo "")
+
+    # Delete the objects in new org
+    echo "Deleting objects in test org.."
+    ORG_MOID=$(./build/isctl ${ISCTL_OPTIONS} get organization organization --name "${TEST_NAME}" -o jsonpath='$.Moid'|| echo "")
+    run ./build/isctl ${ISCTL_OPTIONS} delete ntp policy moid $(./build/isctl ${ISCTL_OPTIONS} get ntp policy --filter "Name eq '${TEST_NAME}' and Organization/Moid eq '${ORG_MOID}'" -o 'jsonpath=$[*].Moid'|| echo "")
+    run ./build/isctl ${ISCTL_OPTIONS} delete iam endpointuser moid $(./build/isctl ${ISCTL_OPTIONS} get iam endpointuser --filter "Name eq '${TEST_NAME}' and Organization/Moid eq '${ORG_MOID}'" -o 'jsonpath=$[*].Moid'|| echo "")
+
+    # Delete org
+    if ! [ -z "${ORG_MOID}" ] 
+    then
+        echo "Deleting org.."
+        ./build/isctl ${ISCTL_OPTIONS} delete organization organization moid ${ORG_MOID}
+    fi
+}


### PR DESCRIPTION
The objects where this works has changed - ntp.Policy no longer allows this but iam.EndPointUser does so the tests have also changed.

Fixes #149 