### PR TITLE
feat: improve apply command to tolerate missing identity attributes 

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -150,16 +150,9 @@ func applyMOs(client *util.IsctlClient, rawMOs []rawMO) error {
 		constraints := meta.GetIdentityConstraints(classID)
 		canIdentify := false
 		if len(constraints) > 0 {
-			allPresent := true
-			for _, f := range constraints {
-				if _, ok := mo[f]; !ok {
-					if f == "Organization" || f == "Account" {
-						continue
-					}
-					allPresent = false
-				}
-			}
-			canIdentify = allPresent
+			// If there are identity constraints, we assume we can identify the object
+			// Missing fields will simply be omitted from the filter
+			canIdentify = true
 		} else {
 			_, canIdentify = mo["Name"]
 		}
@@ -428,7 +421,7 @@ func buildIdentityFilter(client *util.IsctlClient, mo rawMO, meta *oapi.Meta) (s
 				if field == "Organization" {
 					cMoRef = oapi.CanonicaliseMoRef("default", refType)
 				} else {
-					return "", fmt.Errorf("missing required identity field: %s", field)
+					continue
 				}
 			} else {
 				switch attr := attr.(type) {
@@ -459,7 +452,7 @@ func buildIdentityFilter(client *util.IsctlClient, mo rawMO, meta *oapi.Meta) (s
 		} else {
 			val, err := dyno.Get(mo, field)
 			if err != nil {
-				return "", fmt.Errorf("missing required identity field: %s", field)
+				continue
 			}
 			switch val.(type) {
 			case string:

--- a/tests/apply.bats
+++ b/tests/apply.bats
@@ -92,6 +92,21 @@ TEST_SECTION="Apply"
     
 }
 
+@test "${TEST_SECTION}: apply MOs with identity constraints and missing attributes" {
+    # delete the objects first to ensure a clean state
+    run ./build/isctl ${ISCTL_OPTIONS} apply -f tests/data/test-identity-constraints-missing-attr.yaml -d
+
+    run ./build/isctl ${ISCTL_OPTIONS} apply -f tests/data/test-identity-constraints-missing-attr.yaml
+    assert_success
+
+    run ./build/isctl ${ISCTL_OPTIONS} apply -f tests/data/test-identity-constraints-missing-attr.yaml
+    assert_success
+
+    run ./build/isctl ${ISCTL_OPTIONS} apply -f tests/data/test-identity-constraints-missing-attr.yaml -d
+    assert_success
+    
+}
+
 @test "${TEST_SECTION}: apply and delete test-correct-ordering-with-nameless-mos.yaml" {
     run ./build/isctl ${ISCTL_OPTIONS} apply -f tests/data/test-correct-ordering-with-nameless-mos.yaml
     assert_success

--- a/tests/data/test-identity-constraints-missing-attr.yaml
+++ b/tests/data/test-identity-constraints-missing-attr.yaml
@@ -1,0 +1,12 @@
+ClassId: fabric.PortPolicy
+Name: cg-isctl-test-1
+DeviceModel: UCS-FI-6454
+Organization: default
+---
+ClassId: fabric.ServerRole
+#settings
+PortPolicy: MoRef[cg-isctl-test-1]
+AutoNegotiationDisabled: false
+Fec: Auto
+PortId: 9
+SlotId: 1


### PR DESCRIPTION
improve apply command to tolerate missing identity attributes by omitting them from filters and MoRefs.

Resolves #222