### PR TITLE
Fix typos in docs and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you use [Homebrew](https://brew.sh), the easiest way to install `isctl` is:
 brew install cgascoig/isctl/isctl
 ```
 
-If you don't use Homebew:
+If you don't use Homebrew:
 
 * Download the latest release from the [Releases](https://github.com/cgascoig/isctl/releases/latest) page. 
 * Unzip and move the `isctl` binary somewhere that is on your path (e.g. `/usr/local/bin`). 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![User Guide](https://img.shields.io/badge/User%20Guide-Netlify-success)](https://isctl.netlify.app/) [![Build status](https://dev.azure.com/cgascoig/isctl/_apis/build/status/Full%20test?branchName=devel)](https://dev.azure.com/cgascoig/isctl/_build/latest?definitionId=2) [![Go Report](https://goreportcard.com/badge/github.com/cgascoig/isctl)](https://goreportcard.com/report/github.com/cgascoig/isctl)
 # isctl - CLI for Cisco Intersight
-`isctl` is a `kubectl`-insipired CLI for the Cisco Intersight service. 
+`isctl` is a `kubectl`-inspired CLI for the Cisco Intersight service. 
 
 ## Features
 

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -395,12 +395,12 @@ func buildIdentityFilter(client *util.IsctlClient, mo rawMO, meta *oapi.Meta) (s
 
 			orgMoRef, err := gen.GetMoMoRef(client, cMoRef)
 			if err != nil {
-				return "", fmt.Errorf("error finding organisation: %v", err)
+				return "", fmt.Errorf("error finding organization: %v", err)
 			}
 
 			orgMoid, err := dyno.GetString(orgMoRef, "Moid")
 			if err != nil {
-				return "", fmt.Errorf("error finding organisation: %v", err)
+				return "", fmt.Errorf("error finding organization: %v", err)
 			}
 			return fmt.Sprintf("Name eq '%s' and Organization/Moid eq '%s'", name, orgMoid), nil
 		}

--- a/docs/1-basic-queries.md
+++ b/docs/1-basic-queries.md
@@ -60,7 +60,7 @@ isctl get ntp policy --filter "startsWith(Name, 'cg-')"
 
 ## Output customisation
 
-By default, `isctl` will try to produce human readable output. Typically, this will be a table format with boilerplate attributes (e.g. `ClassId`, `Organization`, etc.) hidden for brevity. If the output table would have too many columns, `isctl` will fall back to a "vertical" output (essentially YAML). If you want to disable this behaviour and force the table format (even though it will be very wide), use `--output table`. 
+By default, `isctl` will try to produce human readable output. Typically, this will be a table format with boilerplate attributes (e.g. `ClassId`, `Organization`, etc.) hidden for brevity. If the output table would have too many columns, `isctl` will fall back to a "vertical" output (essentially YAML). If you want to disable this behavior and force the table format (even though it will be very wide), use `--output table`. 
 
 There are a number of other options to customise the output described below.
 

--- a/docs/2-advanced-queries.md
+++ b/docs/2-advanced-queries.md
@@ -63,7 +63,7 @@ Organization:
   DomainGroupMoid: 5b25418d7a7662743465cf72
   ModTime: "2019-12-09T23:25:48.256Z"
   Moid: 5deed7fc6972652d33bc48d0
-  Name: Example Organisation
+  Name: Example Organization
   ObjectType: organization.Organization
   Owners:
   - 123456789012345678901234

--- a/examples/complete_imm/1_domain_profile/README.MD
+++ b/examples/complete_imm/1_domain_profile/README.MD
@@ -4,7 +4,7 @@ Make sure you have [isctl](https://github.com/cgascoig/isctl) installed and conf
 ## Steps
 1. Claim FI Targets, this is a manual UI process for now.
 
-2. Edit all the yamls file to match your environment
+2. Edit all the yaml files to match your environment
 
 3. Apply all the config
 ```
@@ -32,7 +32,7 @@ isctl update fabric switchprofile name IMM-Domain-01-B --Action Unassign
 ```
 
 2. remove the config
-To clean up just rust the `isctl apply` commands but add a `-d` at the end.
+To clean up just run the `isctl apply` commands but add a `-d` at the end.
 ```
 isctl apply -f . -d
 ```

--- a/examples/complete_imm/2_chassis_profile/README.MD
+++ b/examples/complete_imm/2_chassis_profile/README.MD
@@ -2,7 +2,7 @@
 Make sure you have [isctl](https://github.com/cgascoig/isctl) installed and configured.
 
 ## Steps
-1. Update the yaml files to match your environmnet
+1. Update the yaml files to match your environment
 
 2. Apply all the config
 ```
@@ -23,7 +23,7 @@ isctl update chassis profile name IMM-Domain-01-Chassis-01 --Action Unassign
 ```
 
 2. remove the config
-To clean up just rust the `isctl apply` commands but add a `-d` at the end.
+To clean up just run the `isctl apply` commands but add a `-d` at the end.
 ```
 isctl apply -f . -d  
 ```

--- a/examples/complete_imm/3_server_profiles/FI-Attached/README.MD
+++ b/examples/complete_imm/3_server_profiles/FI-Attached/README.MD
@@ -46,7 +46,7 @@ isctl delete server profile name IMM-RHEL-08
 ```
 
 2. remove the config
-To clean up just rust the `isctl apply` commands but add a `-d` at the end.
+To clean up just run the `isctl apply` commands but add a `-d` at the end.
 ```
 isctl apply -f . -d
 ```

--- a/examples/complete_imm/README.md
+++ b/examples/complete_imm/README.md
@@ -9,15 +9,15 @@ There are 3 directories in this repository
 
 ### 1_domain_profile
 This holds all the domain required policies and the Domain profile.
-There is a seperate README in this directory with more information
+There is a separate README in this directory with more information
 
 ### 2_chassis_profile
 This holds all the chassis required policies and the Chassis profile.
-There is a seperate README in this directory with more information
+There is a separate README in this directory with more information
 
 ### 3_server_profiles
-This holds all the server profile required policies, the Server Profile Template and it will derivef 8 Server Profiles that will be assigned through a Server Resource Pool.
-There is a seperate README in this directory with more information
+This holds all the server profile required policies, the Server Profile Template and it will derive 8 Server Profiles that will be assigned through a Server Resource Pool.
+There is a separate README in this directory with more information
 
 All configuration is stored in yaml files and need to be updated to match your environment.
 
@@ -59,4 +59,4 @@ isctl apply -f 3_server_profiles/FI-Attached/.
 
 ## Clean up
 
-there are more details cleanup steps writting in each directory, please clean up in the right order.
+there are more details cleanup steps written in each directory, please clean up in the right order.

--- a/pkg/gen/genutils.go
+++ b/pkg/gen/genutils.go
@@ -29,12 +29,12 @@ func GetMoMoRef(client *util.IsctlClient, moref *oapi.MoRef) (map[string]any, er
 		orgMoRef := oapi.CanonicaliseMoRef(moref.Organization, "organization.Organization.Relationship")
 		resolvedOrgMoRef, err := GetMoMoRef(client, orgMoRef)
 		if err != nil {
-			return nil, fmt.Errorf("error finding organisation: %v", err)
+			return nil, fmt.Errorf("error finding organization: %v", err)
 		}
 
 		orgMoid, err := dyno.GetString(resolvedOrgMoRef, "Moid")
 		if err != nil {
-			return nil, fmt.Errorf("error finding organisation: %v", err)
+			return nil, fmt.Errorf("error finding organization: %v", err)
 		}
 
 		filter = fmt.Sprintf("%s and Organization/Moid eq '%s'", filter, orgMoid)
@@ -57,7 +57,7 @@ func GetMoMoRef(client *util.IsctlClient, moref *oapi.MoRef) (map[string]any, er
 
 	classId, ok := getClassId(res)
 	if !ok {
-		return nil, fmt.Errorf("GetMoMoRef: ubable to get classID")
+		return nil, fmt.Errorf("GetMoMoRef: unable to get classID")
 	}
 
 	log.Debugf("Got Moid and ClassId: %s, %s", moid, classId)

--- a/pkg/oapi/operations.go
+++ b/pkg/oapi/operations.go
@@ -467,7 +467,7 @@ func getTokenListForOperation(op *Operation) ([]string, []string) {
 	methodVerb := methodVerbs[strings.ToLower(op.HTTPMethod)]
 
 	helpList := []string{
-		methodVerb + " resouce(s)",
+		methodVerb + " resource(s)",
 		fmt.Sprintf("%s %s resource(s)", methodVerb, op.BaseName),
 		op.Summary,
 	}

--- a/tests/apply.bats
+++ b/tests/apply.bats
@@ -19,7 +19,7 @@ TEST_SECTION="Apply"
     [ "${NTPSERVERS}" == "[\"1.1.1.1\"]" ]
 }
 
-@test "${TEST_SECTION}: apply directoy of YAML files" {
+@test "${TEST_SECTION}: apply directory of YAML files" {
     ./build/isctl ${ISCTL_OPTIONS} apply -f tests/data/apply-yaml
 }
 

--- a/tests/ntp_policy.bats
+++ b/tests/ntp_policy.bats
@@ -94,7 +94,7 @@ TEST_SECTION="NTP Policy CRUD"
     assert_line --index 3 --regexp "^ +${TEST_NTP_POLICY_NAME} +[0-9a-f]{24} +true *$"
 }
 
-@test "${TEST_SECTION}: expand organisation name" {
+@test "${TEST_SECTION}: expand organization name" {
   ORG=$(./build/isctl ${ISCTL_OPTIONS} get ntp policy --name "${TEST_NTP_POLICY_NAME}" -o json --expand 'Organization($select=Name)' | jq -r .Organization.Name)
   assert_equal "${ORG}" "default"
 }

--- a/tests/organization.bats
+++ b/tests/organization.bats
@@ -23,13 +23,13 @@ TEST_SECTION="Organization"
         --EndPointUserPolicy "MoRef[${TEST_NAME}\\${TEST_NAME}]" \
         --Password hahahahaha
 
-    echo "Deleteing test IAM endpointuserrole in test org"
+    echo "Deleting test IAM endpointuserrole in test org"
     ORG_MOID=$(./build/isctl ${ISCTL_OPTIONS} get organization organization --name "${TEST_NAME}" -o jsonpath='$.Moid'|| echo "")
 
     # Don't need to delete endpointuserrole - it is automatically deleted when the policy is deleted
     # ./build/isctl ${ISCTL_OPTIONS} delete iam endpointuserrole moid $(./build/isctl ${ISCTL_OPTIONS} get iam endpointuserrole --filter "Name eq '${TEST_NAME}' and Organization/Moid eq '${ORG_MOID}'" -o 'jsonpath=$[*].Moid'|| echo "")
 
-    echo "Deleteing test IAM endpointuserpolicy in test org"
+    echo "Deleting test IAM endpointuserpolicy in test org"
     ./build/isctl ${ISCTL_OPTIONS} delete iam endpointuserpolicy moid $(./build/isctl ${ISCTL_OPTIONS} get iam endpointuserpolicy --filter "Name eq '${TEST_NAME}' and Organization/Moid eq '${ORG_MOID}'" -o 'jsonpath=$[*].Moid'|| echo "")
 }
 


### PR DESCRIPTION
I was getting my environment setup to experiment with adding a new feature and figured I would do some grunt work to start off. Please see the summary of fixes below.

Let me know if you need any clarification or corrections.

README.md	insipired	inspired
tests/orginization.bats	filename typo	organization.bats
tests/organization.bats	Deleteing (2x)	Deleting
examples/complete_imm/README.md	seperate (3x)	separate
examples/complete_imm/README.md	derivef	derive
examples/complete_imm/README.md	writting	written
examples/complete_imm/1_domain_profile/README.MD	yamls file	yaml files
examples/complete_imm/1_domain_profile/README.MD	rust	run
examples/complete_imm/2_chassis_profile/README.MD	environmnet	environment
examples/complete_imm/2_chassis_profile/README.MD	rust	run
examples/complete_imm/3_server_profiles/FI-Attached/README.MD	rust	run
cmd/apply.go	organisation (2x)	organization
tests/apply.bats	directoy	directory
pkg/oapi/operations.go	resouce	resource
docs/1-basic-queries.md	behaviour	behavior
README.md	Homebew	Homebrew
pkg/gen/genutils.go	ubable	unable
pkg/gen/genutils.go	organisation (2x)	organization
docs/2-advanced-queries.md	Example Organisation	Example Organization
tests/ntp_policy.bats	expand organisation	expand organization