### PR TITLE
feat: Add an `edit` command for interactive resource modification

### DIFF
--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -1,0 +1,279 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+
+	"github.com/icza/dyno"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	yaml "gopkg.in/yaml.v3"
+
+	"github.com/cgascoig/isctl/pkg/gen"
+	"github.com/cgascoig/isctl/pkg/oapi"
+	"github.com/cgascoig/isctl/pkg/util"
+)
+
+type editConfig struct {
+	client *util.IsctlClient
+}
+
+func newCmdEdit(client *util.IsctlClient) *cobra.Command {
+	log.Trace("Running edit cmd generator")
+	config := editConfig{
+		client: client,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "edit",
+		Short: "Edit an Intersight resource in your default editor",
+		Long: `Edit an Intersight resource using your preferred text editor.
+
+The resource will be fetched, filtered to show only editable properties,
+and opened in your editor. After saving and closing the editor, any changes
+will be applied via an update operation.
+
+The editor is determined by:
+1. $EDITOR environment variable
+2. $VISUAL environment variable  
+3. Platform default (vi on Unix, notepad on Windows)
+
+Examples:
+  # Edit an NTP policy by name
+  isctl edit ntp policy name my-ntp-policy
+
+  # Edit an NTP policy by Moid
+  isctl edit ntp policy moid 1234567890abcdef12345678`,
+	}
+
+	// Generate subcommands from the CLI tree for resources that have update operations
+	cliTree := oapi.GenerateCliTree()
+	config.addEditSubcommands(cmd, cliTree, []string{})
+
+	return cmd
+}
+
+func init() {
+	auxCommandsGenerators = append(auxCommandsGenerators, newCmdEdit)
+}
+
+// addEditSubcommands finds the "update" branch of the CLI tree and mirrors its structure
+// under the edit command.
+func (config *editConfig) addEditSubcommands(parent *cobra.Command, cliTree *oapi.CliItem, path []string) {
+	if cliTree.Children == nil {
+		return
+	}
+
+	// Find the "update" command at the top level - this is the tree we want to mirror
+	updateItem, hasUpdate := cliTree.Children["update"]
+	if !hasUpdate || updateItem.Children == nil {
+		log.Trace("No 'update' command found in CLI tree")
+		return
+	}
+
+	// Recursively build edit subcommands that mirror the update tree structure
+	config.mirrorUpdateTree(parent, updateItem, path)
+}
+
+// mirrorUpdateTree recursively creates edit subcommands that mirror the update command tree
+func (config *editConfig) mirrorUpdateTree(parent *cobra.Command, item *oapi.CliItem, path []string) {
+	if item.Children == nil {
+		return
+	}
+
+	for token, child := range item.Children {
+		// If this has an Operation with a moid/name parameter, create the leaf command
+		if child.Parameter == "moid" || child.Parameter == "name" {
+			paramCmd := config.createEditParamCommand(child, path)
+			if paramCmd != nil {
+				parent.AddCommand(paramCmd)
+			}
+		} else {
+			// This is a grouping node, create a subcommand and recurse
+			subCmd := &cobra.Command{
+				Use:   token,
+				Short: child.Help,
+			}
+			config.mirrorUpdateTree(subCmd, child, append(path, token))
+			// Only add if it has subcommands
+			if len(subCmd.Commands()) > 0 {
+				parent.AddCommand(subCmd)
+			}
+		}
+	}
+}
+
+// createEditParamCommand creates a command for editing by moid or name
+func (config *editConfig) createEditParamCommand(cliItem *oapi.CliItem, path []string) *cobra.Command {
+	if cliItem.Operation == nil {
+		return nil
+	}
+
+	// ReturnClassID() returns schema reference like "#/components/schemas/ntp.Policy"
+	// Convert to class ID like "ntp.Policy" for meta lookups
+	classID := oapi.SchemaNameToClassId(cliItem.Operation.ReturnClassID())
+	paramType := cliItem.Parameter // "moid" or "name"
+
+	cmd := &cobra.Command{
+		Use:   fmt.Sprintf("%s <%s>", paramType, paramType),
+		Short: fmt.Sprintf("Edit by %s", paramType),
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			err := config.runEdit(classID, paramType, args[0])
+			if err != nil {
+				log.Fatalf("Error editing resource: %v", err)
+			}
+		},
+	}
+
+	return cmd
+}
+
+// runEdit executes the edit workflow
+func (config *editConfig) runEdit(classID, paramType, paramValue string) error {
+	// Step 1: Fetch the object
+	log.Debugf("Fetching %s with %s=%s", classID, paramType, paramValue)
+
+	getOperation := gen.GetGetOperationForClassID(classID)
+	if getOperation == nil {
+		return fmt.Errorf("no get operation found for class %s", classID)
+	}
+
+	var queryParams map[string]string
+	var args []string
+
+	if paramType == "name" {
+		queryParams = map[string]string{"filter": fmt.Sprintf("Name eq '%s'", paramValue)}
+	} else {
+		args = []string{paramValue}
+	}
+
+	res, err := getOperation.Execute(config.client, args, queryParams)
+	if err != nil {
+		return fmt.Errorf("error fetching object: %w", err)
+	}
+
+	// Get the Moid for later update
+	moid, ok := util.GetMoid(res)
+	if !ok {
+		return fmt.Errorf("object not found or multiple objects match")
+	}
+
+	// Convert result to map
+	mo, err := resultToMap(res)
+	if err != nil {
+		return fmt.Errorf("error processing result: %w", err)
+	}
+
+	// Step 2: Filter to writable properties and convert to YAML
+	originalYAML, err := oapi.FormatEditableYAML(mo, classID)
+	if err != nil {
+		return fmt.Errorf("error formatting YAML: %w", err)
+	}
+
+	// Step 3: Write to temp file
+	tmpFile, err := os.CreateTemp("", "isctl-edit-*.yaml")
+	if err != nil {
+		return fmt.Errorf("error creating temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	defer os.Remove(tmpPath)
+
+	if _, err := tmpFile.Write(originalYAML); err != nil {
+		tmpFile.Close()
+		return fmt.Errorf("error writing temp file: %w", err)
+	}
+	tmpFile.Close()
+
+	// Step 4: Open editor
+	editor := getEditor()
+	log.Debugf("Opening editor: %s %s", editor, tmpPath)
+
+	editorCmd := exec.Command(editor, tmpPath)
+	editorCmd.Stdin = os.Stdin
+	editorCmd.Stdout = os.Stdout
+	editorCmd.Stderr = os.Stderr
+
+	if err := editorCmd.Run(); err != nil {
+		return fmt.Errorf("error running editor: %w", err)
+	}
+
+	// Step 5: Read modified file
+	modifiedYAML, err := os.ReadFile(tmpPath)
+	if err != nil {
+		return fmt.Errorf("error reading modified file: %w", err)
+	}
+
+	// Step 6: Check if content changed
+	if bytes.Equal(originalYAML, modifiedYAML) {
+		fmt.Println("Edit cancelled, no changes made.")
+		return nil
+	}
+
+	// Step 7: Parse modified YAML
+	var modifiedMO map[string]any
+	if err := yaml.Unmarshal(modifiedYAML, &modifiedMO); err != nil {
+		return fmt.Errorf("error parsing modified YAML: %w", err)
+	}
+
+	// Step 8: Perform update
+	log.Debugf("Updating %s with Moid %s", classID, moid)
+
+	updateOperation := gen.GetUpdateOperationForClassID(classID)
+	if updateOperation == nil {
+		return fmt.Errorf("no update operation found for class %s", classID)
+	}
+
+	if err := updateOperation.SetBodyParams(config.client, modifiedMO); err != nil {
+		return fmt.Errorf("error setting update body: %w", err)
+	}
+
+	_, err = updateOperation.Execute(config.client, []string{moid}, nil)
+	if err != nil {
+		return fmt.Errorf("error executing update: %w", err)
+	}
+
+	fmt.Println("Edit applied successfully.")
+	return nil
+}
+
+// getEditor returns the editor command to use
+func getEditor() string {
+	if editor := os.Getenv("EDITOR"); editor != "" {
+		return editor
+	}
+	if editor := os.Getenv("VISUAL"); editor != "" {
+		return editor
+	}
+	if runtime.GOOS == "windows" {
+		return "notepad"
+	}
+	return "vi"
+}
+
+// resultToMap converts an API result to a map[string]any
+func resultToMap(result any) (map[string]any, error) {
+	// Handle list results (from filter queries)
+	if results, err := dyno.GetSlice(result, "Results"); err == nil {
+		if len(results) == 0 {
+			return nil, fmt.Errorf("no results found")
+		}
+		if len(results) > 1 {
+			return nil, fmt.Errorf("multiple results found, expected exactly one")
+		}
+		if mo, ok := results[0].(map[string]any); ok {
+			return mo, nil
+		}
+		return nil, fmt.Errorf("unexpected result type")
+	}
+
+	// Handle single object result
+	if mo, ok := result.(map[string]any); ok {
+		return mo, nil
+	}
+
+	return nil, fmt.Errorf("unexpected result type: %T", result)
+}

--- a/docs/3-create-update-delete.md
+++ b/docs/3-create-update-delete.md
@@ -74,3 +74,32 @@ Or by Name:
 isctl update ntp policy name isctl-test-1 --Enabled=False
 ```
 
+## Editing resources interactively
+
+For more complex edits, or when you want to review the current state before making changes, use the `isctl edit` command. This opens the resource in your preferred text editor, similar to `kubectl edit`.
+
+```
+isctl edit ntp policy name isctl-test-1
+```
+
+This will:
+1. Fetch the current resource from Intersight
+2. Filter to show only editable properties (read-only fields like Moid and CreateTime are hidden)
+3. Open it in your editor as YAML
+4. After you save and close, apply any changes via an update operation
+
+If you close the editor without making changes, no update is performed.
+
+### Editor selection
+
+The editor is determined by (in order of precedence):
+1. `$EDITOR` environment variable
+2. `$VISUAL` environment variable
+3. Platform default (`vi` on Unix, `notepad` on Windows)
+
+To use a specific editor:
+
+```
+EDITOR=nano isctl edit ntp policy name isctl-test-1
+```
+

--- a/pkg/oapi/editable_yaml.go
+++ b/pkg/oapi/editable_yaml.go
@@ -1,0 +1,60 @@
+package oapi
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// FilterWritableProperties filters a managed object to only include properties
+// and relationships with ApiAccess == "ReadWrite". Returns a new map containing
+// only the writable fields. This is useful for edit operations where users should
+// only modify writable properties.
+func FilterWritableProperties(mo map[string]any, classId string) (map[string]any, error) {
+	meta, err := GetMeta()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load metadata: %w", err)
+	}
+
+	writableProps := meta.GetWritablePropertyNames(classId)
+	writableRels := meta.GetWritableRelationshipNames(classId)
+
+	if writableProps == nil && writableRels == nil {
+		return nil, fmt.Errorf("class %s not found in metadata", classId)
+	}
+
+	// Create a set for O(1) lookup
+	writableSet := make(map[string]bool)
+	for _, name := range writableProps {
+		writableSet[name] = true
+	}
+	for _, name := range writableRels {
+		writableSet[name] = true
+	}
+
+	// Filter the MO to only include writable properties
+	filtered := make(map[string]any)
+	for key, value := range mo {
+		if writableSet[key] {
+			filtered[key] = value
+		}
+	}
+
+	return filtered, nil
+}
+
+// FormatEditableYAML filters a managed object to only include writable properties
+// and marshals it to YAML format. This produces YAML suitable for editing by users.
+func FormatEditableYAML(mo map[string]any, classId string) ([]byte, error) {
+	filtered, err := FilterWritableProperties(mo, classId)
+	if err != nil {
+		return nil, err
+	}
+
+	yamlBytes, err := yaml.Marshal(filtered)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal to YAML: %w", err)
+	}
+
+	return yamlBytes, nil
+}

--- a/pkg/oapi/editable_yaml_test.go
+++ b/pkg/oapi/editable_yaml_test.go
@@ -1,0 +1,155 @@
+package oapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetClassMeta(t *testing.T) {
+	meta, err := GetMeta()
+	require.NoError(t, err)
+
+	t.Run("returns ClassMeta for valid classId", func(t *testing.T) {
+		cm := meta.GetClassMeta("ntp.Policy")
+		require.NotNil(t, cm)
+		assert.Equal(t, "ntp.Policy", cm.Name)
+		assert.True(t, cm.IsConcrete)
+	})
+
+	t.Run("returns nil for invalid classId", func(t *testing.T) {
+		cm := meta.GetClassMeta("nonexistent.Class")
+		assert.Nil(t, cm)
+	})
+}
+
+func TestGetWritablePropertyNames(t *testing.T) {
+	meta, err := GetMeta()
+	require.NoError(t, err)
+
+	t.Run("returns writable property names for valid class", func(t *testing.T) {
+		names := meta.GetWritablePropertyNames("ntp.Policy")
+		require.NotNil(t, names)
+		// NTP Policy should have some writable properties
+		assert.Contains(t, names, "Enabled")
+		assert.Contains(t, names, "Name")
+		assert.Contains(t, names, "NtpServers")
+	})
+
+	t.Run("returns nil for invalid class", func(t *testing.T) {
+		names := meta.GetWritablePropertyNames("nonexistent.Class")
+		assert.Nil(t, names)
+	})
+
+	t.Run("does not include read-only properties", func(t *testing.T) {
+		names := meta.GetWritablePropertyNames("ntp.Policy")
+		// Check that common read-only system properties are not included
+		for _, name := range names {
+			assert.NotEqual(t, "Moid", name)
+			assert.NotEqual(t, "ClassId", name)
+			assert.NotEqual(t, "ObjectType", name)
+		}
+	})
+}
+
+func TestGetWritableRelationshipNames(t *testing.T) {
+	meta, err := GetMeta()
+	require.NoError(t, err)
+
+	t.Run("returns writable relationship names for valid class", func(t *testing.T) {
+		names := meta.GetWritableRelationshipNames("ntp.Policy")
+		require.NotNil(t, names)
+		// NTP Policy has Profiles as a writable relationship
+		assert.Contains(t, names, "Profiles")
+	})
+
+	t.Run("returns nil for invalid class", func(t *testing.T) {
+		names := meta.GetWritableRelationshipNames("nonexistent.Class")
+		assert.Nil(t, names)
+	})
+}
+
+func TestFilterWritableProperties(t *testing.T) {
+	t.Run("filters to only writable properties", func(t *testing.T) {
+		mo := map[string]any{
+			"Name":       "test-policy",
+			"Enabled":    true,
+			"NtpServers": []string{"1.1.1.1"},
+			"Moid":       "12345",
+			"ClassId":    "ntp.Policy",
+			"ObjectType": "ntp.Policy",
+			"CreateTime": "2024-01-01T00:00:00Z",
+		}
+
+		filtered, err := FilterWritableProperties(mo, "ntp.Policy")
+		require.NoError(t, err)
+		require.NotNil(t, filtered)
+
+		// Should include writable properties
+		assert.Contains(t, filtered, "Name")
+		assert.Contains(t, filtered, "Enabled")
+		assert.Contains(t, filtered, "NtpServers")
+
+		// Should not include read-only system properties
+		assert.NotContains(t, filtered, "Moid")
+		assert.NotContains(t, filtered, "ClassId")
+		assert.NotContains(t, filtered, "ObjectType")
+		assert.NotContains(t, filtered, "CreateTime")
+	})
+
+	t.Run("returns error for invalid classId", func(t *testing.T) {
+		mo := map[string]any{"Name": "test"}
+		filtered, err := FilterWritableProperties(mo, "nonexistent.Class")
+		assert.Error(t, err)
+		assert.Nil(t, filtered)
+	})
+
+	t.Run("returns empty map when no writable properties present", func(t *testing.T) {
+		mo := map[string]any{
+			"Moid":       "12345",
+			"ClassId":    "ntp.Policy",
+			"ObjectType": "ntp.Policy",
+		}
+
+		filtered, err := FilterWritableProperties(mo, "ntp.Policy")
+		require.NoError(t, err)
+		require.NotNil(t, filtered)
+		// Should be an empty map since we only passed read-only properties
+		assert.Empty(t, filtered)
+	})
+}
+
+func TestFormatEditableYAML(t *testing.T) {
+	t.Run("produces valid YAML with only writable properties", func(t *testing.T) {
+		mo := map[string]any{
+			"Name":       "test-policy",
+			"Enabled":    true,
+			"NtpServers": []string{"1.1.1.1", "2.2.2.2"},
+			"Moid":       "12345",
+			"ClassId":    "ntp.Policy",
+		}
+
+		yamlBytes, err := FormatEditableYAML(mo, "ntp.Policy")
+		require.NoError(t, err)
+		require.NotEmpty(t, yamlBytes)
+
+		yamlStr := string(yamlBytes)
+		// Should include writable properties
+		assert.Contains(t, yamlStr, "Name")
+		assert.Contains(t, yamlStr, "test-policy")
+		assert.Contains(t, yamlStr, "Enabled")
+		assert.Contains(t, yamlStr, "NtpServers")
+
+		// Should not include read-only properties
+		assert.NotContains(t, yamlStr, "Moid")
+		assert.NotContains(t, yamlStr, "ClassId")
+	})
+
+	t.Run("returns error for invalid classId", func(t *testing.T) {
+		mo := map[string]any{"Name": "test"}
+		yamlBytes, err := FormatEditableYAML(mo, "nonexistent.Class")
+		assert.Error(t, err)
+		assert.Nil(t, yamlBytes)
+	})
+}

--- a/pkg/oapi/meta.go
+++ b/pkg/oapi/meta.go
@@ -165,3 +165,43 @@ func (m *Meta) GetRefType(classId, propName string) (string, bool) {
 	}
 	return "", false
 }
+
+// GetClassMeta returns the ClassMeta for a given class ID, or nil if not found.
+func (m *Meta) GetClassMeta(classId string) *ClassMeta {
+	for i := range *m {
+		if (*m)[i].Name == classId {
+			return &(*m)[i]
+		}
+	}
+	return nil
+}
+
+// GetWritablePropertyNames returns the names of properties with ApiAccess == "ReadWrite".
+func (m *Meta) GetWritablePropertyNames(classId string) []string {
+	cm := m.GetClassMeta(classId)
+	if cm == nil {
+		return nil
+	}
+	var names []string
+	for _, prop := range cm.Properties {
+		if prop.ApiAccess == "ReadWrite" {
+			names = append(names, prop.Name)
+		}
+	}
+	return names
+}
+
+// GetWritableRelationshipNames returns the names of relationships with ApiAccess == "ReadWrite".
+func (m *Meta) GetWritableRelationshipNames(classId string) []string {
+	cm := m.GetClassMeta(classId)
+	if cm == nil {
+		return nil
+	}
+	var names []string
+	for _, rel := range cm.Relationships {
+		if rel.ApiAccess == "ReadWrite" {
+			names = append(names, rel.Name)
+		}
+	}
+	return names
+}

--- a/tests/edit.bats
+++ b/tests/edit.bats
@@ -1,0 +1,85 @@
+TEST_EDIT_POLICY_NAME=isctl-bats-test-edit-policy
+
+TEST_SECTION="Edit Command"
+
+@test "${TEST_SECTION}: help shows available commands" {
+    run ./build/isctl ${ISCTL_OPTIONS} edit --help
+    assert_success
+    assert_line --partial "Edit an Intersight resource"
+    assert_line --partial "edit ntp policy name my-ntp-policy"
+}
+
+@test "${TEST_SECTION}: edit ntp policy shows subcommands" {
+    run ./build/isctl ${ISCTL_OPTIONS} edit ntp policy --help
+    assert_success
+    assert_line --partial "moid"
+    assert_line --partial "name"
+}
+
+@test "${TEST_SECTION}: edit with EDITOR=cat shows no changes" {
+    # Create a test policy first
+    ./build/isctl ${ISCTL_OPTIONS} create ntp policy --Name "${TEST_EDIT_POLICY_NAME}" --NtpServers 1.1.1.1 --Organization default
+
+    # Edit with cat as editor (no changes possible)
+    run env EDITOR=cat ./build/isctl ${ISCTL_OPTIONS} edit ntp policy name "${TEST_EDIT_POLICY_NAME}"
+    assert_success
+    assert_line --partial "no changes made"
+}
+
+@test "${TEST_SECTION}: edit output contains only editable properties" {
+    # Use cat to dump what would be shown in editor
+    run env EDITOR=cat ./build/isctl ${ISCTL_OPTIONS} edit ntp policy name "${TEST_EDIT_POLICY_NAME}"
+    assert_success
+    
+    # Should contain editable properties
+    assert_line --partial "Name"
+    assert_line --partial "Enabled"
+    
+    # Should NOT contain read-only properties
+    refute_line --partial "Moid:"
+    refute_line --partial "ClassId:"
+    refute_line --partial "ObjectType:"
+    refute_line --partial "CreateTime:"
+}
+@test "${TEST_SECTION}: edit actually updates the resource" {
+    # First ensure the policy is enabled
+    ./build/isctl ${ISCTL_OPTIONS} update ntp policy name "${TEST_EDIT_POLICY_NAME}" --Enabled=true
+    
+    # Verify it's enabled
+    ENABLED=$( ./build/isctl ${ISCTL_OPTIONS} get ntp policy --name "${TEST_EDIT_POLICY_NAME}" -o json | jq -r .Enabled )
+    assert_equal "${ENABLED}" "true"
+    
+    # Create a wrapper script that uses sed to change Enabled from true to false
+    EDITOR_SCRIPT=$(mktemp)
+    cat > "${EDITOR_SCRIPT}" << 'EOF'
+#!/bin/bash
+sed -i.bak 's/Enabled: true/Enabled: false/' "$1"
+EOF
+    chmod +x "${EDITOR_SCRIPT}"
+    
+    # Run edit with our sed wrapper as the editor
+    run env EDITOR="${EDITOR_SCRIPT}" ./build/isctl ${ISCTL_OPTIONS} edit ntp policy name "${TEST_EDIT_POLICY_NAME}"
+    rm -f "${EDITOR_SCRIPT}"
+    
+    assert_success
+    assert_line --partial "Edit applied successfully"
+    
+    # Verify the change was actually applied
+    ENABLED=$( ./build/isctl ${ISCTL_OPTIONS} get ntp policy --name "${TEST_EDIT_POLICY_NAME}" -o json | jq -r .Enabled )
+    assert_equal "${ENABLED}" "false"
+}
+
+@test "${TEST_SECTION}: cleanup test policy" {
+    run ./build/isctl ${ISCTL_OPTIONS} delete ntp policy name "${TEST_EDIT_POLICY_NAME}"
+    assert_success
+}
+
+setup_file() {
+    # Clean up any leftover test policy
+    run ./build/isctl ${ISCTL_OPTIONS} delete ntp policy name "${TEST_EDIT_POLICY_NAME}"
+}
+
+setup() {
+    load 'test_helper/bats-support/load'
+    load 'test_helper/bats-assert/load'
+}


### PR DESCRIPTION
Add an `edit` command for interactive resource modification using an external editor

Closes #93