### PR TITLE
Add templating and variable substitution capabilities to apply command

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -25,7 +26,9 @@ var (
 type rawMO = map[string]any
 
 type applyConfig struct {
-	client *util.IsctlClient
+	client   *util.IsctlClient
+	varFlags []string
+	varFile  string
 }
 
 func newCmdApply(client *util.IsctlClient) *cobra.Command {
@@ -42,6 +45,8 @@ func newCmdApply(client *util.IsctlClient) *cobra.Command {
 
 	cmd.Flags().StringSliceVarP(&applyFilenames, "filename", "f", []string{}, "Filename(s) that contains the configuration to apply (comma-separated list)")
 	cmd.Flags().BoolVarP(&applyDelete, "delete", "d", false, "Destroy the configuration instead of creating it")
+	cmd.Flags().StringArrayVar(&config.varFlags, "var", []string{}, "Set variable values (key=value)")
+	cmd.Flags().StringVar(&config.varFile, "var-file", "", "Load variable values from a YAML file")
 
 	return cmd
 }
@@ -53,7 +58,12 @@ func init() {
 func (config *applyConfig) runCmdApply(cmd *cobra.Command, args []string) {
 	// config.client.GetConfig().Debug = verbose
 
-	rawMOs, err := loadRawMOs(applyFilenames)
+	vars, err := config.getVariables()
+	if err != nil {
+		log.Fatalf("Error loading variables: %v", err)
+	}
+
+	rawMOs, err := loadRawMOs(applyFilenames, vars)
 	if err != nil {
 		log.Fatalf("Unable to load MOs: %v", err)
 	}
@@ -203,7 +213,7 @@ func applyMOs(client *util.IsctlClient, rawMOs []rawMO) error {
 	return nil
 }
 
-func loadRawMOs(applyFilenames []string) ([]rawMO, error) {
+func loadRawMOs(applyFilenames []string, vars map[string]interface{}) ([]rawMO, error) {
 	rawMOs := []rawMO{}
 
 	for _, filePath := range applyFilenames {
@@ -221,7 +231,7 @@ func loadRawMOs(applyFilenames []string) ([]rawMO, error) {
 			}
 			filenames := append(filenames1, filenames2...)
 			for _, filename := range filenames {
-				mos, err := loadFile(filename)
+				mos, err := loadFile(filename, vars)
 				if err != nil {
 					return nil, fmt.Errorf("error reading file: %v", err)
 				}
@@ -229,7 +239,7 @@ func loadRawMOs(applyFilenames []string) ([]rawMO, error) {
 				rawMOs = append(rawMOs, mos...)
 			}
 		case mode.IsRegular():
-			mos, err := loadFile(filePath)
+			mos, err := loadFile(filePath, vars)
 			if err != nil {
 				return nil, fmt.Errorf("error reading file: %v", err)
 			}
@@ -243,15 +253,20 @@ func loadRawMOs(applyFilenames []string) ([]rawMO, error) {
 	return rawMOs, nil
 }
 
-func loadFile(filename string) ([]rawMO, error) {
-	in, err := os.Open(filename)
+func loadFile(filename string, vars map[string]interface{}) ([]rawMO, error) {
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
 
+	processedContent, err := processTemplate(content, vars)
+	if err != nil {
+		return nil, fmt.Errorf("error processing template in %s: %w", filename, err)
+	}
+
 	ret := []rawMO{}
 
-	dec := yaml.NewDecoder(in)
+	dec := yaml.NewDecoder(bytes.NewReader(processedContent))
 
 	for {
 		var mo rawMO

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -58,7 +58,7 @@ func init() {
 func (config *applyConfig) runCmdApply(cmd *cobra.Command, args []string) {
 	// config.client.GetConfig().Debug = verbose
 
-	vars, err := config.getVariables()
+	vars, err := config.getVariables(applyFilenames)
 	if err != nil {
 		log.Fatalf("Error loading variables: %v", err)
 	}
@@ -231,6 +231,9 @@ func loadRawMOs(applyFilenames []string, vars map[string]interface{}) ([]rawMO, 
 			}
 			filenames := append(filenames1, filenames2...)
 			for _, filename := range filenames {
+				if filepath.Base(filename) == "isctl.vars.yaml" || filepath.Base(filename) == "isctl.vars.yml" {
+					continue
+				}
 				mos, err := loadFile(filename, vars)
 				if err != nil {
 					return nil, fmt.Errorf("error reading file: %v", err)

--- a/cmd/apply_template.go
+++ b/cmd/apply_template.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -15,10 +16,49 @@ import (
 // 1. Command line flags (--var)
 // 2. Variable file (--var-file)
 // 3. Environment variables (ISCTL_VAR_*)
-func (config *applyConfig) getVariables() (map[string]interface{}, error) {
+// 4. Directory variables (isctl.vars.yaml/yml in directories passed to -f)
+func (config *applyConfig) getVariables(applyFilenames []string) (map[string]interface{}, error) {
 	vars := make(map[string]interface{})
 
-	// 1. Environment variables starting with ISCTL_VAR_
+	// Directory variables (lowest precedence, so loaded first)
+
+	// We need to track where variables came from to detect collisions
+	dirVarSources := make(map[string]string)
+
+	for _, path := range applyFilenames {
+		info, err := os.Stat(path)
+		if err != nil {
+			continue // Skip invalid paths, they will be handled later
+		}
+		if info.IsDir() {
+			// Check for isctl.vars.yaml or isctl.vars.yml
+			for _, ext := range []string{".yaml", ".yml"} {
+				varFileName := "isctl.vars" + ext
+				varFile := filepath.Join(path, varFileName)
+
+				fileInfo, err := os.Stat(varFile)
+				// Check if file exists and is a regular file
+				if err == nil && fileInfo.Mode().IsRegular() {
+					fileVars, err := loadVarFile(varFile)
+					if err != nil {
+						return nil, fmt.Errorf("failed to load directory variable file %s: %w", varFile, err)
+					}
+
+					for k, v := range fileVars {
+						// Check for collisions with other directory variable files
+						if source, exists := dirVarSources[k]; exists {
+							return nil, fmt.Errorf("variable '%s' is defined in multiple directory variable files: %s and %s", k, source, varFile)
+						}
+
+						vars[k] = v
+						dirVarSources[k] = varFile
+					}
+				}
+			}
+		}
+	}
+
+	// Environment variables starting with ISCTL_VAR_
 	for _, env := range os.Environ() {
 		pair := strings.SplitN(env, "=", 2)
 		if len(pair) == 2 && strings.HasPrefix(pair[0], "ISCTL_VAR_") {
@@ -29,7 +69,7 @@ func (config *applyConfig) getVariables() (map[string]interface{}, error) {
 		}
 	}
 
-	// 2. Variable file
+	// Variable file
 	if config.varFile != "" {
 		fileVars, err := loadVarFile(config.varFile)
 		if err != nil {
@@ -40,7 +80,7 @@ func (config *applyConfig) getVariables() (map[string]interface{}, error) {
 		}
 	}
 
-	// 3. Command line flags
+	// Command line flags
 	for _, v := range config.varFlags {
 		pair := strings.SplitN(v, "=", 2)
 		if len(pair) != 2 {

--- a/cmd/apply_template.go
+++ b/cmd/apply_template.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/Masterminds/sprig/v3"
+	"gopkg.in/yaml.v3"
+)
+
+// getVariables loads variables from multiple sources with the following precedence (highest to lowest):
+// 1. Command line flags (--var)
+// 2. Variable file (--var-file)
+// 3. Environment variables (ISCTL_VAR_*)
+func (config *applyConfig) getVariables() (map[string]interface{}, error) {
+	vars := make(map[string]interface{})
+
+	// 1. Environment variables starting with ISCTL_VAR_
+	for _, env := range os.Environ() {
+		pair := strings.SplitN(env, "=", 2)
+		if len(pair) == 2 && strings.HasPrefix(pair[0], "ISCTL_VAR_") {
+			key := strings.TrimPrefix(pair[0], "ISCTL_VAR_")
+			if key != "" {
+				vars[key] = pair[1]
+			}
+		}
+	}
+
+	// 2. Variable file
+	if config.varFile != "" {
+		fileVars, err := loadVarFile(config.varFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load variable file: %w", err)
+		}
+		for k, v := range fileVars {
+			vars[k] = v
+		}
+	}
+
+	// 3. Command line flags
+	for _, v := range config.varFlags {
+		pair := strings.SplitN(v, "=", 2)
+		if len(pair) != 2 {
+			return nil, fmt.Errorf("invalid variable format: %s (expected key=value)", v)
+		}
+		vars[pair[0]] = pair[1]
+	}
+
+	return vars, nil
+}
+
+func loadVarFile(filename string) (map[string]interface{}, error) {
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	var vars map[string]interface{}
+	err = yaml.Unmarshal(content, &vars)
+	if err != nil {
+		return nil, err
+	}
+	return vars, nil
+}
+
+// processTemplate executes the content as a Go template, providing the variables under the "Vars" key.
+// It includes Sprig functions.
+func processTemplate(content []byte, vars map[string]interface{}) ([]byte, error) {
+	tmpl, err := template.New("manifest").Funcs(sprig.FuncMap()).Parse(string(content))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse template: %w", err)
+	}
+
+	data := map[string]interface{}{
+		"Vars": vars,
+	}
+
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute template: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}

--- a/cmd/apply_template_test.go
+++ b/cmd/apply_template_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,7 +29,7 @@ func TestGetVariables(t *testing.T) {
 		varFile:  tmpFile.Name(),
 	}
 
-	vars, err := config.getVariables()
+	vars, err := config.getVariables([]string{})
 	assert.NoError(t, err)
 
 	expected := map[string]interface{}{
@@ -93,4 +94,90 @@ func TestProcessTemplate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetVariablesWithDirectory(t *testing.T) {
+	// Create a temporary directory
+	tmpDir, err := os.MkdirTemp("", "isctl-test")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create isctl.vars.yaml in the directory
+	varFileContent := []byte("DIR_VAR: dir-value\nOVERRIDE_ME: dir-value\nALSO_OVERRIDE_ME: dir-value")
+	err = os.WriteFile(filepath.Join(tmpDir, "isctl.vars.yaml"), varFileContent, 0644)
+	assert.NoError(t, err)
+
+	// Set up environment variables
+	os.Setenv("ISCTL_VAR_ENV_VAR", "env-value")
+	os.Setenv("ISCTL_VAR_OVERRIDE_ME", "env-value")
+	defer os.Unsetenv("ISCTL_VAR_ENV_VAR")
+	defer os.Unsetenv("ISCTL_VAR_OVERRIDE_ME")
+
+	config := &applyConfig{
+		varFlags: []string{"FLAG_VAR=flag-value", "ALSO_OVERRIDE_ME=flag-value"},
+	}
+
+	// Pass the directory as one of the files to apply
+	vars, err := config.getVariables([]string{tmpDir})
+	assert.NoError(t, err)
+
+	expected := map[string]interface{}{
+		"ENV_VAR":          "env-value",
+		"DIR_VAR":          "dir-value",
+		"FLAG_VAR":         "flag-value",
+		"OVERRIDE_ME":      "env-value",  // Env overrides Directory
+		"ALSO_OVERRIDE_ME": "flag-value", // Flag overrides Directory
+	}
+
+	for k, v := range expected {
+		assert.Equal(t, v, vars[k], "Variable %s mismatch", k)
+	}
+}
+
+func TestGetVariablesWithDirectoryCollision(t *testing.T) {
+	// Create two temporary directories
+	tmpDir1, err := os.MkdirTemp("", "isctl-test-1")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir1)
+
+	tmpDir2, err := os.MkdirTemp("", "isctl-test-2")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir2)
+
+	// Create isctl.vars.yaml in both directories defining the same variable
+	varFileContent1 := []byte("COLLISION_VAR: value1")
+	err = os.WriteFile(filepath.Join(tmpDir1, "isctl.vars.yaml"), varFileContent1, 0644)
+	assert.NoError(t, err)
+
+	varFileContent2 := []byte("COLLISION_VAR: value2")
+	err = os.WriteFile(filepath.Join(tmpDir2, "isctl.vars.yaml"), varFileContent2, 0644)
+	assert.NoError(t, err)
+
+	config := &applyConfig{}
+
+	// Pass both directories
+	_, err = config.getVariables([]string{tmpDir1, tmpDir2})
+
+	// Expect an error due to collision
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "variable 'COLLISION_VAR' is defined in multiple directory variable files")
+}
+
+func TestGetVariablesWithDirectoryNotRegularFile(t *testing.T) {
+	// Create a temporary directory
+	tmpDir, err := os.MkdirTemp("", "isctl-test")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create a directory named isctl.vars.yaml (not a regular file)
+	err = os.Mkdir(filepath.Join(tmpDir, "isctl.vars.yaml"), 0755)
+	assert.NoError(t, err)
+
+	config := &applyConfig{}
+
+	// Pass the directory
+	// Should not error, but should not load any variables
+	vars, err := config.getVariables([]string{tmpDir})
+	assert.NoError(t, err)
+	assert.Empty(t, vars)
 }

--- a/cmd/apply_template_test.go
+++ b/cmd/apply_template_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetVariables(t *testing.T) {
+	// Set up environment variables
+	os.Setenv("ISCTL_VAR_ENV_VAR", "env-value")
+	os.Setenv("ISCTL_VAR_OVERRIDE_ME", "env-value")
+	defer os.Unsetenv("ISCTL_VAR_ENV_VAR")
+	defer os.Unsetenv("ISCTL_VAR_OVERRIDE_ME")
+
+	// Create a temporary variable file
+	varFileContent := []byte("FILE_VAR: file-value\nOVERRIDE_ME: file-value\nALSO_OVERRIDE_ME: file-value")
+	tmpFile, err := os.CreateTemp("", "vars.yaml")
+	assert.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	_, err = tmpFile.Write(varFileContent)
+	assert.NoError(t, err)
+	tmpFile.Close()
+
+	config := &applyConfig{
+		varFlags: []string{"FLAG_VAR=flag-value", "ALSO_OVERRIDE_ME=flag-value"},
+		varFile:  tmpFile.Name(),
+	}
+
+	vars, err := config.getVariables()
+	assert.NoError(t, err)
+
+	expected := map[string]interface{}{
+		"ENV_VAR":          "env-value",
+		"FILE_VAR":         "file-value",
+		"FLAG_VAR":         "flag-value",
+		"OVERRIDE_ME":      "file-value", // File overrides Env
+		"ALSO_OVERRIDE_ME": "flag-value", // Flag overrides File
+	}
+
+	for k, v := range expected {
+		assert.Equal(t, v, vars[k], "Variable %s mismatch", k)
+	}
+}
+
+func TestProcessTemplate(t *testing.T) {
+	vars := map[string]interface{}{
+		"Name": "world",
+	}
+
+	tests := []struct {
+		name    string
+		content string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Simple variable",
+			content: "Hello {{ .Vars.Name }}",
+			want:    "Hello world",
+			wantErr: false,
+		},
+		{
+			name:    "Sprig function (upper)",
+			content: "Hello {{ .Vars.Name | upper }}",
+			want:    "Hello WORLD",
+			wantErr: false,
+		},
+		{
+			name:    "Sprig function (default)",
+			content: "Hello {{ .Vars.Missing | default \"nobody\" }}",
+			want:    "Hello nobody",
+			wantErr: false,
+		},
+		{
+			name:    "Invalid template",
+			content: "Hello {{ .Vars.Name }",
+			want:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := processTemplate([]byte(tt.content), vars)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("processTemplate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				assert.Equal(t, tt.want, string(got))
+			}
+		})
+	}
+}

--- a/docs/4-bulk-operations.md
+++ b/docs/4-bulk-operations.md
@@ -113,6 +113,7 @@ Variables can be provided from three sources, in order of precedence (highest to
 1.  **Command-line flags**: `--var key=value`
 2.  **Variable file**: `--var-file path/to/vars.yaml`
 3.  **Environment variables**: `ISCTL_VAR_variableName`
+4.  **Directory variables**: `isctl.vars.yaml` or `isctl.vars.yml` in directories passed to `-f`
 
 ### Functions
 

--- a/docs/4-bulk-operations.md
+++ b/docs/4-bulk-operations.md
@@ -99,3 +99,46 @@ PolicyBucket:
 
 ## Renaming
 For each object in your YAML file, the Name attribute is used to check if the object already exists and determine whether to apply an update or create operation for that object. For this reason, you cannot rename an existing object - isctl will not know about the original name for the object and will simply create a new object and leave the original untouched. 
+
+## Templating and Variables
+
+YAML files processed by `isctl apply` are treated as [Go templates](https://pkg.go.dev/text/template). This allows you to parameterize your manifests and inject values at runtime.
+
+### Variables
+
+You can access variables in your templates using the `{{ .Vars.VariableName }}` syntax.
+
+Variables can be provided from three sources, in order of precedence (highest to lowest):
+
+1.  **Command-line flags**: `--var key=value`
+2.  **Variable file**: `--var-file path/to/vars.yaml`
+3.  **Environment variables**: `ISCTL_VAR_variableName`
+
+### Functions
+
+[Sprig](http://masterminds.github.io/sprig/) functions are available for use in your templates. This includes functions for string manipulation, math, dates, and more.
+
+### Example
+
+**template.yaml**:
+```yaml
+ClassId: ntp.Policy
+Name: {{ .Vars.policyName }}
+Organization: default
+# Use Sprig's default function for optional variables
+Description: "Managed by {{ .Vars.owner | default "admin" | upper }}"
+NtpServers:
+  - {{ .Vars.ntpServer }}
+```
+
+**Apply with variables**:
+```bash
+# Set owner via environment variable
+export ISCTL_VAR_owner="devops"
+
+# Apply with var-file and flags
+isctl apply -f template.yaml \
+  --var-file common-vars.yaml \
+  --var policyName="my-dynamic-policy" \
+  --var ntpServer="10.0.0.1"
+```

--- a/tests/apply_template.bats
+++ b/tests/apply_template.bats
@@ -1,0 +1,80 @@
+load 'test_helper/bats-support/load'
+load 'test_helper/bats-assert/load'
+
+setup() {
+    # common_setup # common setup not found in tests/apply.bats, seemingly not used or implicit?
+    # actually apply.bats doesn't load common. It defines setup() locally.
+    # I'll just use what I need.
+    :
+}
+
+teardown() {
+    # Clean up the test object if it exists
+    ./build/isctl apply -d -f "$BATS_TEST_TMPDIR/template.yaml" --var myname="template-test" || true
+}
+
+@test "apply creates object using templates and variable precedence" {
+    # cleanup any stale objects
+    run ./build/isctl delete ntp policy name template-test
+
+    # 1. Create a template file
+    cat <<EOF > "$BATS_TEST_TMPDIR/template.yaml"
+ClassId: ntp.Policy
+Name: {{ .Vars.myname }}
+Organization: default
+Description: "Created by {{ .Vars.owner | default "unknown" }} from {{ .Vars.source | upper }} Env Test: {{ .Vars.envtest }}"
+NtpServers:
+  - 1.2.3.4
+EOF
+
+    # 2. Create a variables file
+    cat <<EOF > "$BATS_TEST_TMPDIR/vars.yaml"
+myname: file-name
+owner: file-owner
+source: file-source
+EOF
+
+    # 3. Apply with flags overriding file, and file overriding env
+    # ISCTL_VAR_owner=env-owner (overridden by file)
+    # --var-file (provides defaults)
+    # --var myname=template-test (overrides file)
+    
+    export ISCTL_VAR_owner="env-owner"
+    export ISCTL_VAR_source="env-source"
+    export ISCTL_VAR_envtest="env-test"
+    
+    run ./build/isctl apply -f "$BATS_TEST_TMPDIR/template.yaml" \
+        --var-file "$BATS_TEST_TMPDIR/vars.yaml" \
+        --var myname="template-test"
+
+    assert_success
+    assert_output --partial "Performing create operation on new MO"
+    assert_output --partial "Name: template-test"
+
+    # 4. Verify the object was created with correct values
+    # Name should be "template-test" (from flag)
+    # Description should check precedence: 
+    #   owner: "file-owner" (file overrides env)
+    #   source: "file-source" (file overrides env) -> upper -> "FILE-SOURCE"
+    
+    run ./build/isctl get ntp policy --name template-test -o yaml
+    assert_success
+    assert_output --partial "Name: template-test"
+    assert_output --partial "Description: 'Created by file-owner from FILE-SOURCE Env Test: env-test'"
+    
+    unset ISCTL_VAR_owner
+    unset ISCTL_VAR_source
+    unset ISCTL_VAR_envtest
+}
+
+@test "apply fails with missing variable and no default" {
+    cat <<EOF > "$BATS_TEST_TMPDIR/invalid_template.yaml"
+ClassId: ntp.Policy
+Name: {{ .Vars.missing }}
+EOF
+
+    run ./build/isctl apply -f "$BATS_TEST_TMPDIR/invalid_template.yaml"
+    assert_failure
+    # Template processing succeeds (empty value), but API validation fails because Name is empty/invalid
+    assert_output --partial "Cannot set the property 'policy.AbstractPolicy.Name'"
+}

--- a/tests/apply_template.bats
+++ b/tests/apply_template.bats
@@ -78,3 +78,51 @@ EOF
     # Template processing succeeds (empty value), but API validation fails because Name is empty/invalid
     assert_output --partial "Cannot set the property 'policy.AbstractPolicy.Name'"
 }
+
+@test "apply loads variables from isctl.vars.yaml in directory" {
+    # cleanup any stale objects
+    run ./build/isctl delete ntp policy name dir-var-test
+
+    # 1. Create a directory structure
+    mkdir -p "$BATS_TEST_TMPDIR/subdir"
+
+    # 2. Create a template file in the directory
+    cat <<EOF > "$BATS_TEST_TMPDIR/subdir/template.yaml"
+ClassId: ntp.Policy
+Name: {{ .Vars.name }}
+Organization: default
+Description: "Loaded from {{ .Vars.source }}"
+NtpServers:
+  - 1.2.3.4
+EOF
+
+    # 3. Create isctl.vars.yaml in the directory
+    cat <<EOF > "$BATS_TEST_TMPDIR/subdir/isctl.vars.yaml"
+name: dir-var-test
+source: dir-file
+EOF
+
+    # 4. Apply the directory
+    run ./build/isctl apply -f "$BATS_TEST_TMPDIR/subdir"
+    assert_success
+    assert_output --partial "Performing create operation on new MO"
+    assert_output --partial "Name: dir-var-test"
+
+    # 5. Verify object
+    run ./build/isctl get ntp policy --name dir-var-test -o yaml
+    assert_success
+    assert_output --partial "Name: dir-var-test"
+    assert_output --partial "Description: Loaded from dir-file"
+
+    # 6. Verify precedence (env > dir)
+    export ISCTL_VAR_source="env-override"
+    run ./build/isctl apply -f "$BATS_TEST_TMPDIR/subdir"
+    assert_success
+    
+    run ./build/isctl get ntp policy --name dir-var-test -o yaml
+    assert_success
+    assert_output --partial "Description: Loaded from env-override"
+    
+    unset ISCTL_VAR_source
+    rm -rf "$BATS_TEST_TMPDIR/subdir"
+}

--- a/tests/apply_template.bats
+++ b/tests/apply_template.bats
@@ -10,12 +10,12 @@ setup() {
 
 teardown() {
     # Clean up the test object if it exists
-    ./build/isctl apply -d -f "$BATS_TEST_TMPDIR/template.yaml" --var myname="template-test" || true
+    ./build/isctl ${ISCTL_OPTIONS} apply -d -f "$BATS_TEST_TMPDIR/template.yaml" --var myname="template-test" || true
 }
 
 @test "apply creates object using templates and variable precedence" {
     # cleanup any stale objects
-    run ./build/isctl delete ntp policy name template-test
+    run ./build/isctl ${ISCTL_OPTIONS} delete ntp policy name template-test
 
     # 1. Create a template file
     cat <<EOF > "$BATS_TEST_TMPDIR/template.yaml"
@@ -43,7 +43,7 @@ EOF
     export ISCTL_VAR_source="env-source"
     export ISCTL_VAR_envtest="env-test"
     
-    run ./build/isctl apply -f "$BATS_TEST_TMPDIR/template.yaml" \
+    run ./build/isctl ${ISCTL_OPTIONS} apply -f "$BATS_TEST_TMPDIR/template.yaml" \
         --var-file "$BATS_TEST_TMPDIR/vars.yaml" \
         --var myname="template-test"
 
@@ -57,7 +57,7 @@ EOF
     #   owner: "file-owner" (file overrides env)
     #   source: "file-source" (file overrides env) -> upper -> "FILE-SOURCE"
     
-    run ./build/isctl get ntp policy --name template-test -o yaml
+    run ./build/isctl ${ISCTL_OPTIONS} get ntp policy --name template-test -o yaml
     assert_success
     assert_output --partial "Name: template-test"
     assert_output --partial "Description: 'Created by file-owner from FILE-SOURCE Env Test: env-test'"
@@ -73,7 +73,7 @@ ClassId: ntp.Policy
 Name: {{ .Vars.missing }}
 EOF
 
-    run ./build/isctl apply -f "$BATS_TEST_TMPDIR/invalid_template.yaml"
+    run ./build/isctl ${ISCTL_OPTIONS} apply -f "$BATS_TEST_TMPDIR/invalid_template.yaml"
     assert_failure
     # Template processing succeeds (empty value), but API validation fails because Name is empty/invalid
     assert_output --partial "Cannot set the property 'policy.AbstractPolicy.Name'"
@@ -81,7 +81,7 @@ EOF
 
 @test "apply loads variables from isctl.vars.yaml in directory" {
     # cleanup any stale objects
-    run ./build/isctl delete ntp policy name dir-var-test
+    run ./build/isctl ${ISCTL_OPTIONS} delete ntp policy name dir-var-test
 
     # 1. Create a directory structure
     mkdir -p "$BATS_TEST_TMPDIR/subdir"
@@ -103,23 +103,23 @@ source: dir-file
 EOF
 
     # 4. Apply the directory
-    run ./build/isctl apply -f "$BATS_TEST_TMPDIR/subdir"
+    run ./build/isctl ${ISCTL_OPTIONS} apply -f "$BATS_TEST_TMPDIR/subdir"
     assert_success
     assert_output --partial "Performing create operation on new MO"
     assert_output --partial "Name: dir-var-test"
 
     # 5. Verify object
-    run ./build/isctl get ntp policy --name dir-var-test -o yaml
+    run ./build/isctl ${ISCTL_OPTIONS} get ntp policy --name dir-var-test -o yaml
     assert_success
     assert_output --partial "Name: dir-var-test"
     assert_output --partial "Description: Loaded from dir-file"
 
     # 6. Verify precedence (env > dir)
     export ISCTL_VAR_source="env-override"
-    run ./build/isctl apply -f "$BATS_TEST_TMPDIR/subdir"
+    run ./build/isctl ${ISCTL_OPTIONS} apply -f "$BATS_TEST_TMPDIR/subdir"
     assert_success
     
-    run ./build/isctl get ntp policy --name dir-var-test -o yaml
+    run ./build/isctl ${ISCTL_OPTIONS} get ntp policy --name dir-var-test -o yaml
     assert_success
     assert_output --partial "Description: Loaded from env-override"
     


### PR DESCRIPTION
Add templating and variable substitution capabilities to `isctl apply` using Go templates, Sprig functions, and variable precedence from flags, files, and environment variables.

Closes #234 