### PR TITLE
fix: prevent panics from unchecked type assertions and index access

### DIFF
--- a/cmd/output.go
+++ b/cmd/output.go
@@ -480,6 +480,9 @@ func prepareResultTableCustomColumns(result interface{}, template string) ([][]s
 		// If there is no template, get all the column spec from the first object returned
 
 		if inList, ok := result.([]interface{}); ok {
+			if len(inList) < 1 {
+				return tableData, tableHeaders
+			}
 			// Get the headers from the first element
 			firstRow := inList[0]
 			if rowMap, ok := firstRow.(map[string]interface{}); ok {

--- a/cmd/output_test.go
+++ b/cmd/output_test.go
@@ -364,6 +364,11 @@ func TestPrepareResultTableCustomColums(t *testing.T) {
 	for i := range expectedData {
 		assert.Equal(t, expectedData[i], outData[i])
 	}
+
+	// Test empty list with no template — must not panic
+	outData, outHeaders = prepareResultTableCustomColumns([]interface{}{}, "")
+	assert.Empty(t, outHeaders)
+	assert.Empty(t, outData)
 }
 
 func TestRelaxedJSONPathExpression(t *testing.T) {

--- a/pkg/extension/extension.go
+++ b/pkg/extension/extension.go
@@ -151,10 +151,17 @@ func goToPy(o interface{}) py.Object {
 }
 
 func tupleToFormat(args py.Tuple) (string, []interface{}) {
-	values := pyToGo(args).([]interface{})
-	format := values[0].(string)
-	values = values[1:]
-	return format, values
+	valuesIntf, ok := pyToGo(args).([]interface{})
+	if !ok || len(valuesIntf) == 0 {
+		log.Warn("extension log function called with no arguments")
+		return "", nil
+	}
+	format, ok := valuesIntf[0].(string)
+	if !ok {
+		log.Warn("extension log function: first argument must be a string")
+		return "", nil
+	}
+	return format, valuesIntf[1:]
 }
 
 func getOutputFn(of OutputFunction) func(_ py.Object, args py.Tuple) (py.Object, error) {
@@ -172,6 +179,9 @@ func getOutputFn(of OutputFunction) func(_ py.Object, args py.Tuple) (py.Object,
 			}
 		}
 
+		if len(argsFromPy) < 1 {
+			return nil, fmt.Errorf("output: requires at least one argument")
+		}
 		of(argsFromPy[0], multiPartResult)
 		return nil, nil
 	}

--- a/pkg/extension/extension_test.go
+++ b/pkg/extension/extension_test.go
@@ -3,6 +3,7 @@ package extension
 import (
 	"testing"
 
+	"github.com/go-python/gpython/py"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -35,6 +36,21 @@ func TestInvalidCode(t *testing.T) {
 
 	err = e.SetCode(code)
 	assert.NotNil(t, err)
+}
+
+func TestTupleToFormatNoArgs(t *testing.T) {
+	// Must not panic when called with an empty tuple
+	f, a := tupleToFormat(py.Tuple{})
+	assert.Equal(t, "", f)
+	assert.Nil(t, a)
+}
+
+func TestGetOutputFnNoArgs(t *testing.T) {
+	called := false
+	fn := getOutputFn(func(res any, multi bool) { called = true })
+	_, err := fn(nil, py.Tuple{})
+	assert.Error(t, err)
+	assert.False(t, called)
 }
 
 func TestGetCommand(t *testing.T) {

--- a/pkg/oapi/operations.go
+++ b/pkg/oapi/operations.go
@@ -50,6 +50,9 @@ func ToCamelCase(in string) string {
 	ret := ""
 
 	for _, word := range words {
+		if word == "" {
+			continue
+		}
 		ret = ret + strings.ToUpper(string(word[0])) + word[1:]
 	}
 

--- a/pkg/oapi/operations_test.go
+++ b/pkg/oapi/operations_test.go
@@ -38,6 +38,14 @@ func TestFindOperation(t *testing.T) {
 	assert.Equal(t, "DeleteNtpPolicy", op.OperationID)
 }
 
+func TestToCamelCase(t *testing.T) {
+	assert.Equal(t, "Ntp", ToCamelCase("ntp"))
+	assert.Equal(t, "NtpServer", ToCamelCase("ntp-server"))
+	assert.Equal(t, "Ntp", ToCamelCase("-ntp"))
+	assert.Equal(t, "Ntp", ToCamelCase("ntp-"))
+	assert.Equal(t, "Ntp", ToCamelCase("--ntp"))
+}
+
 func TestRedundantPrefixes(t *testing.T) {
 	f := removeRedundantPrefixes()
 	assert.Equal(t, []string{"get", "ntp", "Policy"}, f([]string{"get", "ntp", "GetNtpPolicy"}))


### PR DESCRIPTION
Closes #245

## Summary

- `ToCamelCase`: skip empty words produced by `regexp.Split` when input has leading/trailing/repeated delimiters (e.g. `-ntp`)
- `tupleToFormat`: replace unchecked `.([]interface{})` assertion and unconditional `values[0]` access with safe checked assertion + length guard
- `getOutputFn`: add `len(argsFromPy) < 1` check before accessing `argsFromPy[0]`
- `prepareResultTableCustomColumns`: add early-return guard for empty result list, matching the pattern already used in `prepareResultTable`

## Test plan

- [ ] `gmake test` passes with all existing and new tests green
- [ ] New tests: `TestToCamelCase`, `TestTupleToFormatNoArgs`, `TestGetOutputFnNoArgs`, and empty-list case in `TestPrepareResultTableCustomColums` all pass without panic