### PR TITLE
fix: address silently ignored errors, data races, resource leaks, and stdout warning

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -275,8 +276,11 @@ func loadFile(filename string, vars map[string]interface{}) ([]rawMO, error) {
 
 	for {
 		var mo rawMO
-		if dec.Decode(&mo) != nil {
-			return ret, nil // no more documents in YAML file
+		if err := dec.Decode(&mo); err != nil {
+			if err == io.EOF {
+				return ret, nil
+			}
+			return nil, fmt.Errorf("error decoding YAML document in %s: %w", filename, err)
 		}
 
 		// skip empty documents

--- a/cmd/extensions.go
+++ b/cmd/extensions.go
@@ -40,7 +40,9 @@ func getExecuteOperationFunction(client *util.IsctlClient) extension.ExecuteOper
 		}
 
 		if body != nil {
-			op.SetBodyParams(client, body)
+			if err := op.SetBodyParams(client, body); err != nil {
+				return nil, fmt.Errorf("error setting operation body: %w", err)
+			}
 		}
 
 		var res any

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -45,8 +45,9 @@ func main() {
 		if err != nil {
 			log.Fatalf("creating cpu profile file: %v", err)
 		}
+		defer f.Close()              // deferred first → runs LAST
 		pprof.StartCPUProfile(f)
-		defer pprof.StopCPUProfile()
+		defer pprof.StopCPUProfile() // deferred second → runs FIRST
 	}
 
 	rootCmd := gen.GetCommands(client, resultHandler)

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -622,7 +622,9 @@ func setXLSXSheet(f *excelize.File, sheetName string, tableData [][]string, tabl
 	if err != nil {
 		log.Errorf("xlsx style error: %v", err)
 	}
-	f.SetCellStyle(sheetName, "A1", "EZ1", style)
+	if err := f.SetCellStyle(sheetName, "A1", "EZ1", style); err != nil {
+		log.Errorf("xlsx set cell style error: %v", err)
+	}
 
 	for row := range tableData {
 		err = f.SetSheetRow(sheetName, fmt.Sprintf("A%d", row+2), &tableData[row])
@@ -672,7 +674,9 @@ func outputResultXLSX(result any, filename string, multiPartResults bool) {
 		}
 	}
 
-	f.DeleteSheet("Sheet1")
+	if err := f.DeleteSheet("Sheet1"); err != nil {
+		log.Errorf("error deleting default sheet from xlsx: %v", err)
+	}
 
 	// Save spreadsheet by the given path.
 	if err := f.SaveAs(filename); err != nil {
@@ -702,6 +706,7 @@ func (t *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 
 	outres, err := httputil.DumpResponse(res, true)
 	if err != nil {
+		res.Body.Close()
 		return nil, err
 	}
 

--- a/pkg/gen/genutils.go
+++ b/pkg/gen/genutils.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/icza/dyno"
 	log "github.com/sirupsen/logrus"
@@ -13,12 +14,18 @@ import (
 	"github.com/cgascoig/isctl/pkg/util"
 )
 
-var momorefCache = map[oapi.MoRef]map[string]any{}
+var (
+	momorefCache      = map[oapi.MoRef]map[string]any{}
+	momorefCacheMutex sync.RWMutex
+)
 
 func GetMoMoRef(client *util.IsctlClient, moref *oapi.MoRef) (map[string]any, error) {
 	log.Debugf("Looking up Mo by MoRef %v", *moref)
 
-	if mo, ok := momorefCache[*moref]; ok {
+	momorefCacheMutex.RLock()
+	mo, ok := momorefCache[*moref]
+	momorefCacheMutex.RUnlock()
+	if ok {
 		log.Trace("Returning MoMoRef from cache")
 		return mo, nil
 	}
@@ -48,7 +55,9 @@ func GetMoMoRef(client *util.IsctlClient, moref *oapi.MoRef) (map[string]any, er
 		if err != nil {
 			return nil, err
 		}
+		momorefCacheMutex.Lock()
 		momorefCache[*moref] = ret
+		momorefCacheMutex.Unlock()
 		return ret, nil
 	}
 
@@ -75,7 +84,9 @@ func GetMoMoRef(client *util.IsctlClient, moref *oapi.MoRef) (map[string]any, er
 		"ObjectType": classId,
 	}
 
+	momorefCacheMutex.Lock()
 	momorefCache[*moref] = ret
+	momorefCacheMutex.Unlock()
 
 	return ret, nil
 }

--- a/pkg/oapi/meta.go
+++ b/pkg/oapi/meta.go
@@ -73,24 +73,21 @@ var metaData []byte
 
 var (
 	meta      *Meta
+	metaErr   error
 	metaMutex sync.Once
 )
 
 // GetMeta lazily loads and returns the metadata.
 func GetMeta() (*Meta, error) {
-	if meta != nil {
-		return meta, nil
-	}
-
-	var err error
 	metaMutex.Do(func() {
 		var m Meta
-		err = json.Unmarshal(metaData, &m)
-		if err == nil {
-			meta = &m
+		if err := json.Unmarshal(metaData, &m); err != nil {
+			metaErr = err
+			return
 		}
+		meta = &m
 	})
-	return meta, err
+	return meta, metaErr
 }
 
 // GetIdentityConstraints returns the identity constraint fields for a given class ID.

--- a/pkg/oapi/operations.go
+++ b/pkg/oapi/operations.go
@@ -84,7 +84,7 @@ func SchemaNameToType(sn string) string {
 	regex := regexp.MustCompile(`^#/components/schemas/([^/]+)$`)
 	m := regex.FindStringSubmatch(sn)
 	if m == nil || len(m) != 2 {
-		fmt.Printf("WARN: SchemaNameToType returning unknown for '%s'", sn)
+		log.Warnf("SchemaNameToType returning unknown for '%s'", sn)
 		return ""
 	}
 
@@ -101,8 +101,7 @@ func getParam(paramName string) *Param {
 
 	p, err := dyno.GetMapS(lazyLoadSpec(), "components", "parameters", paramName)
 	if err != nil {
-		log.WithField("param_name", paramName).Debug("parameter not found")
-		return nil
+		log.Fatalf("error getting parameter %s from spec: %v", paramName, err)
 	}
 
 	name, _ := dyno.GetString(p, "name")
@@ -168,7 +167,7 @@ func getOperations() []Operation {
 	operations := []Operation{}
 	paths, err := dyno.GetMapS(lazyLoadSpec(), "paths")
 	if err != nil {
-		log.Error("error getting paths from spec")
+		log.Fatalf("error getting paths from spec: %v", err)
 	}
 
 	for path, pathSpec := range paths {

--- a/pkg/oapi/spec.go
+++ b/pkg/oapi/spec.go
@@ -3,6 +3,7 @@ package oapi
 import (
 	_ "embed"
 	"encoding/json"
+	"sync"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -10,21 +11,18 @@ import (
 //go:embed "intersight-openapi.json"
 var specData []byte
 
-var spec any
+var (
+	spec     map[string]any
+	specOnce sync.Once
+)
 
 func lazyLoadSpec() map[string]any {
-	if spec == nil {
+	specOnce.Do(func() {
 		log.Trace("begin unmarshalling JSON spec")
-		err := json.Unmarshal(specData, &spec)
-		if err != nil {
-			log.Errorf("error unmarshaling spec: %v", err)
+		if err := json.Unmarshal(specData, &spec); err != nil {
+			log.Fatalf("Error loading spec: %v", err)
 		}
 		log.Trace("finished JSON unmarshal")
-	}
-
-	if spec, ok := spec.(map[string]any); ok {
-		return spec
-	}
-
-	return nil
+	})
+	return spec
 }

--- a/pkg/oapi/spec_test.go
+++ b/pkg/oapi/spec_test.go
@@ -1,6 +1,7 @@
 package oapi
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/icza/dyno"
@@ -8,10 +9,38 @@ import (
 )
 
 func TestLazyLoadSpec(t *testing.T) {
-	spec = lazyLoadSpec()
-	assert.NotNil(t, spec)
+	s := lazyLoadSpec()
+	assert.NotNil(t, s)
 
-	oapi, err := dyno.Get(spec, "openapi")
+	oapi, err := dyno.Get(s, "openapi")
 	assert.NoError(t, err)
 	assert.Equal(t, "3.0.2", oapi)
+}
+
+func TestLazyLoadSpecConcurrency(t *testing.T) {
+	const goroutines = 10
+	var wg sync.WaitGroup
+	results := make(chan map[string]any, goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s := lazyLoadSpec()
+			results <- s
+		}()
+	}
+
+	wg.Wait()
+	close(results)
+
+	// Check all returned the same pointer
+	var firstResult map[string]any
+	for s := range results {
+		if firstResult == nil {
+			firstResult = s
+		} else {
+			assert.Equal(t, firstResult, s, "concurrent lazyLoadSpec() calls should return same map")
+		}
+	}
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -25,7 +25,7 @@ type IsctlClient struct {
 func ReadBody(bodyFormat string, bodyParamMap interface{}) error {
 	if bodyFormat == "json" {
 		// Gather body from JSON on stdin.
-		fmt.Println("Waiting for JSON body: ")
+		fmt.Fprintln(os.Stderr, "Waiting for JSON body: ")
 		err := json.NewDecoder(os.Stdin).Decode(bodyParamMap)
 		if err != nil {
 			return fmt.Errorf("error decoding JSON: %v", err)
@@ -34,7 +34,7 @@ func ReadBody(bodyFormat string, bodyParamMap interface{}) error {
 		log.Tracef("After JSON parse, bodyParamMap: %v", bodyParamMap)
 	} else if bodyFormat == "yaml" {
 		// Gather body from YAML on stdin.
-		fmt.Println("Waiting for YAML body: ")
+		fmt.Fprintln(os.Stderr, "Waiting for YAML body: ")
 		err := yaml.NewDecoder(os.Stdin).Decode(bodyParamMap)
 		if err != nil {
 			return fmt.Errorf("error decoding YAML: %v", err)


### PR DESCRIPTION
## Summary

- Fix silently ignored errors throughout the codebase (issue #246)
- Eliminate data races on global mutable state (issue #247)
- Close CPU profile file handle and HTTP response body on error paths (issue #248)
- Redirect diagnostic warning from stdout to logger to avoid corrupting structured output (issue #249)

## Test plan

- [ ] Run unit tests: `gmake test`
- [ ] Run functional tests: `gmake functional-test`

Closes #246
Closes #247
Closes #248
Closes #249