### PR TITLE
feat: support typed direct-Moid MoRefs with ObjectType in yaml-editable output

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The ultimate command-line companion for Cisco Intersight. Designed for DevOps pr
 * **OpenAPI-Driven:** Automatically generated from the Intersight OpenAPI v3 spec, ensuring capability with the latest features.
 * **Cross-Platform:** Native binaries for macOS, Linux, and Windows.
 * **Flexible Authentication:** Supports both API Key and OAuth 2.0 authentication with automatic [token caching](https://isctl.netlify.app/6-configuration/).
-* **Developer Friendly:** Human, JSON, or YAML output with [JSONpath](https://goessner.net/articles/JsonPath/) and [Go Template](https://pkg.go.dev/text/template) support for powerful data extraction.
+* **Developer Friendly:** Human, JSON, or YAML output with [JSONpath](https://goessner.net/articles/JsonPath/) and [Go Template](https://pkg.go.dev/text/template) support for powerful data extraction. MoRefs can be emitted with human-readable identity values using `--readable-morefs`.
 * **Shell Autocompletion:** Native support for [Bash, Zsh, Fish, and PowerShell](https://isctl.netlify.app/7-shell-autocompletion/).
 * **Operational Reports:** Built-in reports for [HCL compliance, Contract status](https://isctl.netlify.app/8-reports/), and more.
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -36,6 +36,7 @@ const (
 	CKIntersightTokenUrl          = "intersight_token_url"
 	CKIntersightTokenCachePath    = "intersight_token_cache_path"
 	CKIntersightDisableTokenCache = "intersight_disable_token_cache"
+	CKReadableMoRefs              = "readable_morefs"
 
 	// New cmd flags
 	FlagIntersightApiKeyId          = "intersight-api-key-id"
@@ -47,6 +48,7 @@ const (
 	FlagIntersightTokenUrl          = "intersight-token-url"
 	FlagIntersightTokenCachePath    = "intersight-token-cache-path"
 	FlagIntersightDisableTokenCache = "intersight-disable-token-cache"
+	FlagReadableMoRefs              = "readable-morefs"
 
 	// Legacy / deprecated config keys
 	CKKeyID    = "keyID"
@@ -113,6 +115,7 @@ func loadDefaults() {
 		CKIntersightTokenUrl:          "",
 		CKIntersightTokenCachePath:    "",
 		CKIntersightDisableTokenCache: false,
+		CKReadableMoRefs:              false,
 	}, "."), nil)
 }
 
@@ -186,6 +189,7 @@ func loadFlags(flags *flag.FlagSet) {
 		FlagIntersightTokenUrl:          CKIntersightTokenUrl,
 		FlagIntersightTokenCachePath:    CKIntersightTokenCachePath,
 		FlagIntersightDisableTokenCache: CKIntersightDisableTokenCache,
+		FlagReadableMoRefs:              CKReadableMoRefs,
 	}
 
 	err := gK.Load(posflag.ProviderWithFlag(flags, ".", gK, func(f *flag.Flag) (string, any) {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -37,6 +37,7 @@ const (
 	CKIntersightTokenCachePath    = "intersight_token_cache_path"
 	CKIntersightDisableTokenCache = "intersight_disable_token_cache"
 	CKReadableMoRefs              = "readable_morefs"
+	CKIncludeEmptyFields          = "include_empty_fields"
 
 	// New cmd flags
 	FlagIntersightApiKeyId          = "intersight-api-key-id"
@@ -49,6 +50,7 @@ const (
 	FlagIntersightTokenCachePath    = "intersight-token-cache-path"
 	FlagIntersightDisableTokenCache = "intersight-disable-token-cache"
 	FlagReadableMoRefs              = "readable-morefs"
+	FlagIncludeEmptyFields          = "include-empty-fields"
 
 	// Legacy / deprecated config keys
 	CKKeyID    = "keyID"
@@ -116,6 +118,7 @@ func loadDefaults() {
 		CKIntersightTokenCachePath:    "",
 		CKIntersightDisableTokenCache: false,
 		CKReadableMoRefs:              false,
+		CKIncludeEmptyFields:          false,
 	}, "."), nil)
 }
 
@@ -190,6 +193,7 @@ func loadFlags(flags *flag.FlagSet) {
 		FlagIntersightTokenCachePath:    CKIntersightTokenCachePath,
 		FlagIntersightDisableTokenCache: CKIntersightDisableTokenCache,
 		FlagReadableMoRefs:              CKReadableMoRefs,
+		FlagIncludeEmptyFields:          CKIncludeEmptyFields,
 	}
 
 	err := gK.Load(posflag.ProviderWithFlag(flags, ".", gK, func(f *flag.Flag) (string, any) {

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -169,7 +169,7 @@ func (config *editConfig) runEdit(classID, paramType, paramValue string) error {
 	}
 
 	// Step 2: Filter to writable properties and convert to YAML
-	originalYAML, err := oapi.FormatEditableYAML(mo, classID)
+	originalYAML, err := oapi.FormatEditableYAML(mo, classID, gK.Bool(CKIncludeEmptyFields))
 	if err != nil {
 		return fmt.Errorf("error formatting YAML: %w", err)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -70,6 +70,7 @@ func main() {
 	rootCmd.PersistentFlags().String(FlagIntersightTokenCachePath, "", "Path to cache OAuth tokens (default: $XDG_CONFIG_HOME/isctl/token-cache.json)")
 	rootCmd.PersistentFlags().Bool(FlagIntersightDisableTokenCache, false, "Disable OAuth token caching")
 	rootCmd.PersistentFlags().Bool(FlagReadableMoRefs, false, "Display MoRefs using identity constraints instead of Moid where possible")
+	rootCmd.PersistentFlags().Bool(FlagIncludeEmptyFields, false, "Include empty/null fields in yaml-editable output (default: omit empty fields)")
 
 	rootCmd.PersistentFlags().String(CKKeyID, "", "API Key ID [deprecated]")
 	rootCmd.PersistentFlags().String(CKKeyFile, "", "API Private Key Filename [deprecated]")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -69,6 +69,7 @@ func main() {
 	rootCmd.PersistentFlags().String(FlagIntersightTokenUrl, "", "Intersight Token URL")
 	rootCmd.PersistentFlags().String(FlagIntersightTokenCachePath, "", "Path to cache OAuth tokens (default: $XDG_CONFIG_HOME/isctl/token-cache.json)")
 	rootCmd.PersistentFlags().Bool(FlagIntersightDisableTokenCache, false, "Disable OAuth token caching")
+	rootCmd.PersistentFlags().Bool(FlagReadableMoRefs, false, "Display MoRefs using identity constraints instead of Moid where possible")
 
 	rootCmd.PersistentFlags().String(CKKeyID, "", "API Key ID [deprecated]")
 	rootCmd.PersistentFlags().String(CKKeyFile, "", "API Private Key Filename [deprecated]")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -76,13 +76,14 @@ func main() {
 	rootCmd.PersistentFlags().String(CKServer, "intersight.com", "Intersight API Server Address (e.g.\"intersight.com\") [deprecated]")
 	rootCmd.PersistentFlags().BoolP(CKInsecure, "k", false, "Allow insecure server connections (disable SSL certificate validation)")
 
-	rootCmd.PersistentFlags().StringP(CKOutputFormat, "o", "default", `Output format. One of default|yaml|json|table|jsonpath|custom-columns|csv|xlsx|go-template. Examples:
+	rootCmd.PersistentFlags().StringP(CKOutputFormat, "o", "default", `Output format. One of default|yaml|json|table|jsonpath|custom-columns|csv|xlsx|go-template|yaml-editable. Examples:
 	Get Name attribute from all NTP policies: isctl get ntp policy -o jsonpath="[*].Name"
 	Table with just Name and Enabled attributes: isctl get ntp policy -o custom-columns=NAME:.Name,ENABLED:.Enabled
 	Output to CSV with default columns: isctl get ntp policy -o csv > out.csv
 	Output to CSV with custom columns: isctl get ntp policy -o csv=NAME:.Name,ENABLED:.Enabled > out.csv
 	Output to XLSX: isctl get ntp policy -o xlsx=out.xlsx
 	Go template output: isctl get ntp policy --name test -o go-template='{{.Name}}'
+	Editable YAML (writable properties only, MoRefs as typed shorthand): isctl get ntp policy --name test -o yaml-editable
 	See [https://isctl.netlify.app/1-basic-queries/#output-customisation]`)
 	rootCmd.PersistentFlags().StringVar(&jsonPathFilter, "jsonpath", "", "JSONPath filter to apply to the result (e.g. \"$.Name\")")
 

--- a/cmd/moref_resolver.go
+++ b/cmd/moref_resolver.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/icza/dyno"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/cgascoig/isctl/pkg/gen"
+	"github.com/cgascoig/isctl/pkg/oapi"
+	"github.com/cgascoig/isctl/pkg/util"
+)
+
+// MoRefResolver resolves MoRef Moids to human-readable identity strings
+// using identity constraints from meta.json.
+type MoRefResolver struct {
+	client *util.IsctlClient
+	meta   *oapi.Meta
+	cache  map[string]string // "objectType/moid" -> resolved identity string
+}
+
+// NewMoRefResolver creates a new MoRefResolver.
+func NewMoRefResolver(client *util.IsctlClient) (*MoRefResolver, error) {
+	meta, err := oapi.GetMeta()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load metadata: %w", err)
+	}
+	return &MoRefResolver{
+		client: client,
+		meta:   meta,
+		cache:  make(map[string]string),
+	}, nil
+}
+
+// ResolveResult recursively walks result (map[string]any or []any), finds mo.MoRef
+// maps, and annotates them with a "_ResolvedIdentity" key containing the
+// identity-based representation. Falls back to Moid if resolution fails.
+func (r *MoRefResolver) ResolveResult(result any) any {
+	switch v := result.(type) {
+	case map[string]any:
+		if classId, ok := v["ClassId"].(string); ok && classId == "mo.MoRef" {
+			if objectType, ok := v["ObjectType"].(string); ok {
+				if moid, ok := v["Moid"].(string); ok {
+					if identity, ok := r.resolveIdentity(objectType, moid); ok {
+						v["_ResolvedIdentity"] = identity
+					}
+				}
+			}
+			return v
+		}
+		for k, val := range v {
+			v[k] = r.ResolveResult(val)
+		}
+		return v
+	case []any:
+		for i, item := range v {
+			v[i] = r.ResolveResult(item)
+		}
+		return v
+	default:
+		return result
+	}
+}
+
+// resolveIdentity resolves a Moid to an identity string for the given objectType.
+// Returns ("", false) if the class has no identity constraints or resolution fails.
+func (r *MoRefResolver) resolveIdentity(objectType, moid string) (string, bool) {
+	cacheKey := objectType + "/" + moid
+	if cached, ok := r.cache[cacheKey]; ok {
+		return cached, true
+	}
+
+	constraints := r.meta.GetIdentityConstraints(objectType)
+	if len(constraints) == 0 {
+		return "", false
+	}
+
+	// Fetch the object to get its identity field values
+	op := gen.GetGetOperationForClassID(objectType)
+	if op == nil {
+		log.Debugf("readable-morefs: no GET operation for %s, falling back to Moid", objectType)
+		return "", false
+	}
+
+	// Build $select with identity fields + Moid
+	selectFields := append([]string{"Moid"}, constraints...)
+	res, err := op.Execute(r.client, nil, map[string]string{
+		"filter": fmt.Sprintf("Moid eq '%s'", moid),
+		"select": strings.Join(selectFields, ","),
+	})
+	if err != nil {
+		log.Debugf("readable-morefs: error fetching %s/%s: %v", objectType, moid, err)
+		return "", false
+	}
+
+	// Extract the single result
+	results, err := dyno.GetSlice(res, "Results")
+	if err != nil || len(results) != 1 {
+		log.Debugf("readable-morefs: expected 1 result for %s/%s, got error or wrong count", objectType, moid)
+		return "", false
+	}
+	obj, ok := results[0].(map[string]any)
+	if !ok {
+		return "", false
+	}
+
+	// Build the identity string from constraint fields
+	var parts []string
+	for _, field := range constraints {
+		// Skip Account (matches buildIdentityFilter behaviour in apply.go)
+		if field == "Account" {
+			continue
+		}
+
+		_, isRef := r.meta.GetRefType(objectType, field)
+		if isRef {
+			// Relationship field — resolve it recursively
+			refMap, err := dyno.GetMapS(obj, field)
+			if err != nil {
+				log.Debugf("readable-morefs: could not get relationship field %s: %v", field, err)
+				continue
+			}
+			refMoid, ok1 := refMap["Moid"].(string)
+			refObjectType, ok2 := refMap["ObjectType"].(string)
+			if !ok1 || !ok2 {
+				continue
+			}
+			// Try to recursively resolve the referenced object's identity
+			innerIdentity, innerOk := r.resolveIdentity(refObjectType, refMoid)
+			if innerOk {
+				parts = append(parts, fmt.Sprintf("%s:MoRef:%s[%s]", field, refObjectType, innerIdentity))
+			} else {
+				parts = append(parts, fmt.Sprintf("%s:MoRef:%s[Moid:%s]", field, refObjectType, refMoid))
+			}
+		} else {
+			// Scalar field
+			val, err := dyno.Get(obj, field)
+			if err != nil {
+				log.Debugf("readable-morefs: could not get field %s: %v", field, err)
+				continue
+			}
+			parts = append(parts, fmt.Sprintf("%s:%v", field, val))
+		}
+	}
+
+	if len(parts) == 0 {
+		return "", false
+	}
+
+	identity := strings.Join(parts, ",")
+	r.cache[cacheKey] = identity
+	return identity, true
+}

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -55,6 +55,15 @@ func resultHandler(result interface{}, err error, options ...util.ResultOpt) {
 		log.Fatalf("ERROR applying jsonPath filter: %v", err)
 	}
 
+	if gK.Bool(CKReadableMoRefs) {
+		resolver, resolverErr := NewMoRefResolver(client)
+		if resolverErr == nil {
+			result = resolver.ResolveResult(result)
+		} else {
+			log.Debugf("readable-morefs: failed to create resolver: %v", resolverErr)
+		}
+	}
+
 	structuredOutputHandler(result, false)
 }
 
@@ -175,7 +184,11 @@ func collapseReferences(mo *map[string]interface{}) {
 	for k, v := range *mo {
 		if in, ok := v.(map[string]interface{}); ok {
 			if classID, ok := in["ClassId"]; ok && classID == "mo.MoRef" {
-				(*mo)[k] = fmt.Sprintf("MoRef[%v/%v]", in["ObjectType"], in["Moid"])
+				if identity, ok := in["_ResolvedIdentity"].(string); ok {
+					(*mo)[k] = fmt.Sprintf("MoRef[%v/%v]", in["ObjectType"], identity)
+				} else {
+					(*mo)[k] = fmt.Sprintf("MoRef[%v/%v]", in["ObjectType"], in["Moid"])
+				}
 			}
 		}
 	}

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -361,10 +361,33 @@ func applyJSONPathFilter(result interface{}, jsonpathQuery string, singleResult 
 
 const defaultOutputMaxColumns int = 11
 
-func printResultDefault(result interface{}) {
-	result = filterAttributes(result)
+// deepCopyResult returns a deep copy of a result value so that in-place mutations
+// (e.g. by filterAttributes) do not affect the original.
+func deepCopyResult(v interface{}) interface{} {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		cp := make(map[string]interface{}, len(val))
+		for k, item := range val {
+			cp[k] = deepCopyResult(item)
+		}
+		return cp
+	case []interface{}:
+		cp := make([]interface{}, len(val))
+		for i, item := range val {
+			cp[i] = deepCopyResult(item)
+		}
+		return cp
+	default:
+		return v
+	}
+}
 
-	tableData, tableHeaders := prepareResultTable(result, true)
+func printResultDefault(result interface{}) {
+	// filterAttributes mutates maps in-place, so keep a copy for yaml-editable fallback
+	original := deepCopyResult(result)
+	filtered := filterAttributes(result)
+
+	tableData, tableHeaders := prepareResultTable(filtered, true)
 
 	if len(tableHeaders) == 0 {
 		for _, row := range tableData {
@@ -376,18 +399,18 @@ func printResultDefault(result interface{}) {
 		return
 	}
 
-	// Pretty rough but if the output will be very wide fall back to YAML formatting the output unless the output format is explicitly set to "table"
+	// Pretty rough but if the output will be very wide fall back to yaml-editable unless the output format is explicitly set to "table"
 	outputFormat := strings.ToLower(gK.String(CKOutputFormat))
 	if (len(tableHeaders) > defaultOutputMaxColumns) && outputFormat != "table" {
-		log.Println("Too many columns for table format, falling back to vertical output. NOTE: this is not valid YAML; use --output yaml to get valid YAML.")
-		printResultYAML(result)
+		log.Println("Too many columns for table format, falling back to yaml-editable output.")
+		printResultYAMLEditable(original)
 		return
 	}
 
-	// If the result is just 1 item also fall back to YAML unless table is explicitly specified
+	// If the result is just 1 item also fall back to yaml-editable unless table is explicitly specified
 	if len(tableData) == 1 && outputFormat != "table" {
-		log.Println("Single result, falling back to vertical output. NOTE: this is not valid YAML; use --output yaml to get valid YAML.")
-		printResultYAML(result)
+		log.Println("Single result, falling back to yaml-editable output.")
+		printResultYAMLEditable(original)
 		return
 	}
 
@@ -444,7 +467,7 @@ func printSingleMOEditable(result interface{}) {
 		moAny[k] = v
 	}
 
-	out, err := oapi.FormatEditableYAML(moAny, objectType)
+	out, err := oapi.FormatEditableYAML(moAny, objectType, gK.Bool(CKIncludeEmptyFields))
 	if err != nil {
 		log.Errorf("error formatting editable YAML: %v", err)
 		return

--- a/docs/1-basic-queries.md
+++ b/docs/1-basic-queries.md
@@ -248,13 +248,58 @@ isctl get ntp policy --name "test-policy" -o yaml-editable
 Output:
 ```yaml
 AuthenticatedNtpServers: []
+ClassId: ntp.Policy
 Description: ""
 Enabled: true
+Moid: 5ee1aa076275722d3122a944
 Name: test-policy
 NtpServers:
 - 10.10.10.10
 - 10.10.10.12
+ObjectType: ntp.Policy
+Organization: MoRef:organization.Organization[Moid:59c84e4a16267c0001c23428]
+Profiles: []
+Tags: []
 Timezone: Pacific/Niue
 ```
 
 Compare this to `-o yaml` which includes all properties, including read-only ones.
+
+### Readable MoRefs
+
+By default, MoRef values in output use opaque Moid hex strings (e.g., `MoRef:organization.Organization[Moid:59c84e4a16267c0001c23428]`). The `--readable-morefs` flag replaces these with human-readable identity-based values determined by the class's identity constraints in the Intersight schema:
+
+```
+isctl get ntp policy --name "test-policy" --readable-morefs -o yaml-editable
+```
+Output:
+```yaml
+AuthenticatedNtpServers: []
+ClassId: ntp.Policy
+Description: ""
+Enabled: true
+Moid: 5ee1aa076275722d3122a944
+Name: test-policy
+NtpServers:
+- 10.10.10.10
+- 10.10.10.12
+ObjectType: ntp.Policy
+Organization: MoRef:organization.Organization[Name:default]
+Profiles: []
+Tags: []
+Timezone: Pacific/Niue
+```
+
+The identity fields used depend on the class — for example, `organization.Organization` uses `Name`, while `fabric.Vlan` uses `VlanId` and `EthNetworkPolicy`. Classes with no identity constraints fall back to the Moid format.
+
+For classes with multi-field identity, the MoRef includes all identity fields:
+```yaml
+EthNetworkPolicy: MoRef:fabric.Vlan[VlanId:100,EthNetworkPolicy:MoRef:fabric.EthNetworkPolicy[Name:my-policy]]
+```
+
+The `--readable-morefs` flag applies to all output formats (default/table and `yaml-editable`). The resulting `yaml-editable` output is round-trippable — it can be passed back to `isctl apply` without modification.
+
+This option can also be set persistently in the config file:
+```yaml
+readable_morefs: true
+```

--- a/docs/6-configuration.md
+++ b/docs/6-configuration.md
@@ -26,9 +26,10 @@ When using OAuth authentication, `isctl` caches the access token to disk to avoi
 
 ### General Configuration
 
- - **Intersight FQDN** - Fully Qualified Domain Name of the Intersight service. For SaaS this will be `intersight.com` (and this is the default if not specified) but for Private Virtual Appliance (PVA) or Connected Virtual Appliance (CVA) installations you will need to set this. 
- - **Intersight Insecure** - if set to **true**, `isctl` will not verify the certificate of the Intersight API service. If set to **false** (the default), the Intersight API service certificate will be verified. 
+ - **Intersight FQDN** - Fully Qualified Domain Name of the Intersight service. For SaaS this will be `intersight.com` (and this is the default if not specified) but for Private Virtual Appliance (PVA) or Connected Virtual Appliance (CVA) installations you will need to set this.
+ - **Intersight Insecure** - if set to **true**, `isctl` will not verify the certificate of the Intersight API service. If set to **false** (the default), the Intersight API service certificate will be verified.
  - **Intersight Proxy** - The URL of an HTTP proxy to use for API requests (e.g. `http://proxy.example.com:8080`).
+ - **Readable MoRefs** - if set to **true**, MoRef values in output will use human-readable identity fields (e.g., `MoRef:organization.Organization[Name:default]`) instead of opaque Moid hex strings. The identity fields used depend on each class's identity constraints. Falls back to Moid for classes with no identity constraints. See [Readable MoRefs](../1-basic-queries/#readable-morefs) for details.
 
 ## Configuration Sources
 
@@ -45,5 +46,10 @@ Source                | Token Cache Path                   | Disable Token Cache
 Command Line Flags    | `--intersight-token-cache-path`    | `--intersight-disable-token-cache`
 Environment Variables | `INTERSIGHT_TOKEN_CACHE_PATH`      | `INTERSIGHT_DISABLE_TOKEN_CACHE`
 Configuration file    | `intersight_token_cache_path`      | `intersight_disable_token_cache`
+
+Source                | Readable MoRefs
+----------------------|----------------
+Command Line Flags    | `--readable-morefs`
+Configuration file    | `readable_morefs`
 
 > Note: Environment variables are case-insensitive.

--- a/pkg/gen/genutils.go
+++ b/pkg/gen/genutils.go
@@ -22,6 +22,17 @@ var (
 func GetMoMoRef(client *util.IsctlClient, moref *oapi.MoRef) (map[string]any, error) {
 	log.Debugf("Looking up Mo by MoRef %v", *moref)
 
+	if moref.Moid != "" {
+		ret := map[string]any{
+			"ClassId": "mo.MoRef",
+			"Moid":    moref.Moid,
+		}
+		if moref.RelationshipType != "" {
+			ret["ObjectType"] = getClassIDFromRelationship(moref.RelationshipType)
+		}
+		return ret, nil
+	}
+
 	momorefCacheMutex.RLock()
 	mo, ok := momorefCache[*moref]
 	momorefCacheMutex.RUnlock()

--- a/pkg/gen/genutils.go
+++ b/pkg/gen/genutils.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	momorefCache      = map[oapi.MoRef]map[string]any{}
+	momorefCache      = map[string]map[string]any{}
 	momorefCacheMutex sync.RWMutex
 )
 
@@ -33,8 +33,33 @@ func GetMoMoRef(client *util.IsctlClient, moref *oapi.MoRef) (map[string]any, er
 		return ret, nil
 	}
 
+	// Handle multi-field identity MoRefs by building a compound filter
+	if len(moref.IdentityFields) > 0 {
+		parts := []string{}
+		for _, field := range moref.IdentityFields {
+			if field.Ref != nil {
+				resolved, err := GetMoMoRef(client, field.Ref)
+				if err != nil {
+					return nil, fmt.Errorf("error resolving identity field %s: %v", field.Name, err)
+				}
+				moid, err := dyno.GetString(resolved, "Moid")
+				if err != nil {
+					return nil, fmt.Errorf("error getting Moid for identity field %s: %v", field.Name, err)
+				}
+				parts = append(parts, fmt.Sprintf("%s/Moid eq '%s'", field.Name, moid))
+			} else {
+				parts = append(parts, fmt.Sprintf("%s eq '%s'", field.Name, field.Value))
+			}
+		}
+		// Build a modified moref with the compound filter and fall through to filter-based resolution
+		moref = &oapi.MoRef{
+			Filter:           strings.Join(parts, " and "),
+			RelationshipType: moref.RelationshipType,
+		}
+	}
+
 	momorefCacheMutex.RLock()
-	mo, ok := momorefCache[*moref]
+	mo, ok := momorefCache[fmt.Sprintf("%v", *moref)]
 	momorefCacheMutex.RUnlock()
 	if ok {
 		log.Trace("Returning MoMoRef from cache")
@@ -67,7 +92,7 @@ func GetMoMoRef(client *util.IsctlClient, moref *oapi.MoRef) (map[string]any, er
 			return nil, err
 		}
 		momorefCacheMutex.Lock()
-		momorefCache[*moref] = ret
+		momorefCache[fmt.Sprintf("%v", *moref)] = ret
 		momorefCacheMutex.Unlock()
 		return ret, nil
 	}
@@ -96,7 +121,7 @@ func GetMoMoRef(client *util.IsctlClient, moref *oapi.MoRef) (map[string]any, er
 	}
 
 	momorefCacheMutex.Lock()
-	momorefCache[*moref] = ret
+	momorefCache[fmt.Sprintf("%v", *moref)] = ret
 	momorefCacheMutex.Unlock()
 
 	return ret, nil

--- a/pkg/gen/genutils_test.go
+++ b/pkg/gen/genutils_test.go
@@ -4,7 +4,32 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/cgascoig/isctl/pkg/oapi"
 )
+
+func TestGetMoMoRefDirectMoid(t *testing.T) {
+	moref := &oapi.MoRef{Moid: "59c84e4a16267c0001c23428"}
+	result, err := GetMoMoRef(nil, moref)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]any{
+		"ClassId": "mo.MoRef",
+		"Moid":    "59c84e4a16267c0001c23428",
+	}, result)
+	_, hasObjectType := result["ObjectType"]
+	assert.False(t, hasObjectType)
+}
+
+func TestGetMoMoRefDirectMoidWithType(t *testing.T) {
+	moref := &oapi.MoRef{Moid: "59c84e4a16267c0001c23428", RelationshipType: "server.Profile"}
+	result, err := GetMoMoRef(nil, moref)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]any{
+		"ClassId":    "mo.MoRef",
+		"Moid":       "59c84e4a16267c0001c23428",
+		"ObjectType": "server.Profile",
+	}, result)
+}
 
 func TestReplaceArgs(t *testing.T) {
 	var s string

--- a/pkg/oapi/editable_yaml.go
+++ b/pkg/oapi/editable_yaml.go
@@ -159,12 +159,69 @@ func filterNestedSlice(s []any, meta *Meta, parentClassId string, propName strin
 	return filtered
 }
 
+// StripEmptyFields recursively removes entries from a map where the value is
+// nil, an empty string, an empty slice, or an empty map (after recursive stripping).
+// Values like false and 0 are preserved as they are meaningful.
+func StripEmptyFields(m map[string]any) map[string]any {
+	result := make(map[string]any)
+	for k, v := range m {
+		stripped := stripEmptyValue(v)
+		if stripped != nil {
+			result[k] = stripped
+		}
+	}
+	return result
+}
+
+// stripEmptyValue returns nil if the value should be considered empty, otherwise
+// returns the value (recursively stripped if it is a map or slice).
+func stripEmptyValue(v any) any {
+	if v == nil {
+		return nil
+	}
+	switch val := v.(type) {
+	case string:
+		if val == "" {
+			return nil
+		}
+		return val
+	case map[string]any:
+		stripped := StripEmptyFields(val)
+		if len(stripped) == 0 {
+			return nil
+		}
+		return stripped
+	case []any:
+		if len(val) == 0 {
+			return nil
+		}
+		result := make([]any, 0, len(val))
+		for _, item := range val {
+			stripped := stripEmptyValue(item)
+			if stripped != nil {
+				result = append(result, stripped)
+			}
+		}
+		if len(result) == 0 {
+			return nil
+		}
+		return result
+	default:
+		return v
+	}
+}
+
 // FormatEditableYAML filters a managed object to only include writable properties
 // and marshals it to YAML format. This produces YAML suitable for editing by users.
-func FormatEditableYAML(mo map[string]any, classId string) ([]byte, error) {
+// When includeEmptyFields is false (the default), empty/null fields are omitted.
+func FormatEditableYAML(mo map[string]any, classId string, includeEmptyFields bool) ([]byte, error) {
 	filtered, err := FilterWritableProperties(mo, classId)
 	if err != nil {
 		return nil, err
+	}
+
+	if !includeEmptyFields {
+		filtered = StripEmptyFields(filtered)
 	}
 
 	yamlBytes, err := yaml.Marshal(filtered)

--- a/pkg/oapi/editable_yaml.go
+++ b/pkg/oapi/editable_yaml.go
@@ -64,6 +64,9 @@ func filterNestedValue(value any, meta *Meta, parentClassId string, propName str
 		// Collapse MoRef objects to shorthand syntax
 		if classId, ok := v["ClassId"].(string); ok && classId == "mo.MoRef" {
 			if moid, ok := v["Moid"].(string); ok {
+				if objectType, ok := v["ObjectType"].(string); ok && objectType != "" {
+					return fmt.Sprintf("MoRef:%s[Moid:%s]", objectType, moid)
+				}
 				return fmt.Sprintf("MoRef[Moid:%s]", moid)
 			}
 		}

--- a/pkg/oapi/editable_yaml.go
+++ b/pkg/oapi/editable_yaml.go
@@ -63,15 +63,18 @@ func filterNestedValue(value any, meta *Meta, parentClassId string, propName str
 	case map[string]any:
 		// Collapse MoRef objects to shorthand syntax
 		if classId, ok := v["ClassId"].(string); ok && classId == "mo.MoRef" {
+			objectType, _ := v["ObjectType"].(string)
+			expectedType := meta.GetPropertyOrRelationshipType(parentClassId, propName)
+			includeType := objectType != "" && objectType != expectedType
 			// Use pre-resolved identity string if available (from --readable-morefs)
 			if identity, ok := v["_ResolvedIdentity"].(string); ok {
-				if objectType, ok := v["ObjectType"].(string); ok && objectType != "" {
+				if includeType {
 					return fmt.Sprintf("MoRef:%s[%s]", objectType, identity)
 				}
 				return fmt.Sprintf("MoRef[%s]", identity)
 			}
 			if moid, ok := v["Moid"].(string); ok {
-				if objectType, ok := v["ObjectType"].(string); ok && objectType != "" {
+				if includeType {
 					return fmt.Sprintf("MoRef:%s[Moid:%s]", objectType, moid)
 				}
 				return fmt.Sprintf("MoRef[Moid:%s]", moid)

--- a/pkg/oapi/editable_yaml.go
+++ b/pkg/oapi/editable_yaml.go
@@ -47,29 +47,39 @@ func FilterWritableProperties(mo map[string]any, classId string) (map[string]any
 	filtered := make(map[string]any)
 	for key, value := range mo {
 		if writableSet[key] {
-			// Recursively filter nested objects
-			filtered[key] = filterNestedValue(value, meta)
+			// Recursively filter nested objects, passing classId and key for context
+			filtered[key] = filterNestedValue(value, meta, classId, key)
 		}
 	}
 
 	return filtered, nil
 }
 
-// filterNestedValue recursively filters nested objects and slices
-func filterNestedValue(value any, meta *Meta) any {
+// filterNestedValue recursively filters nested objects and slices.
+// parentClassId and propName provide context about where this value appears,
+// used to look up declared types for ClassId/ObjectType omission.
+func filterNestedValue(value any, meta *Meta, parentClassId string, propName string) any {
 	switch v := value.(type) {
 	case map[string]any:
-		return filterNestedMap(v, meta)
+		// Collapse MoRef objects to shorthand syntax
+		if classId, ok := v["ClassId"].(string); ok && classId == "mo.MoRef" {
+			if moid, ok := v["Moid"].(string); ok {
+				return fmt.Sprintf("MoRef[Moid:%s]", moid)
+			}
+		}
+		return filterNestedMap(v, meta, parentClassId, propName)
 	case []any:
-		return filterNestedSlice(v, meta)
+		return filterNestedSlice(v, meta, parentClassId, propName)
 	default:
 		return value
 	}
 }
 
 // filterNestedMap filters a nested map, recursively filtering its contents
-// based on the ObjectType's class metadata
-func filterNestedMap(m map[string]any, meta *Meta) map[string]any {
+// based on the ObjectType's class metadata.
+// parentClassId and propName are the caller's context, used to look up the
+// declared type of this object for ClassId/ObjectType omission.
+func filterNestedMap(m map[string]any, meta *Meta, parentClassId string, propName string) map[string]any {
 	filtered := make(map[string]any)
 
 	// Check if this nested object has an ObjectType that we can use to filter
@@ -111,18 +121,27 @@ func filterNestedMap(m map[string]any, meta *Meta) map[string]any {
 			}
 		}
 
-		// Recursively filter nested values
-		filtered[key] = filterNestedValue(value, meta)
+		// Recursively filter nested values using current object's type for child context
+		filtered[key] = filterNestedValue(value, meta, objectType, key)
+	}
+
+	// Omit ClassId/ObjectType if the nested object's ClassId matches the declared type
+	expectedType := meta.GetPropertyOrRelationshipType(parentClassId, propName)
+	if expectedType != "" {
+		if classId, ok := filtered["ClassId"].(string); ok && classId == expectedType {
+			delete(filtered, "ClassId")
+			delete(filtered, "ObjectType")
+		}
 	}
 
 	return filtered
 }
 
 // filterNestedSlice filters each item in a slice
-func filterNestedSlice(s []any, meta *Meta) []any {
+func filterNestedSlice(s []any, meta *Meta, parentClassId string, propName string) []any {
 	filtered := make([]any, len(s))
 	for i, item := range s {
-		filtered[i] = filterNestedValue(item, meta)
+		filtered[i] = filterNestedValue(item, meta, parentClassId, propName)
 	}
 	return filtered
 }

--- a/pkg/oapi/editable_yaml.go
+++ b/pkg/oapi/editable_yaml.go
@@ -63,6 +63,13 @@ func filterNestedValue(value any, meta *Meta, parentClassId string, propName str
 	case map[string]any:
 		// Collapse MoRef objects to shorthand syntax
 		if classId, ok := v["ClassId"].(string); ok && classId == "mo.MoRef" {
+			// Use pre-resolved identity string if available (from --readable-morefs)
+			if identity, ok := v["_ResolvedIdentity"].(string); ok {
+				if objectType, ok := v["ObjectType"].(string); ok && objectType != "" {
+					return fmt.Sprintf("MoRef:%s[%s]", objectType, identity)
+				}
+				return fmt.Sprintf("MoRef[%s]", identity)
+			}
 			if moid, ok := v["Moid"].(string); ok {
 				if objectType, ok := v["ObjectType"].(string); ok && objectType != "" {
 					return fmt.Sprintf("MoRef:%s[Moid:%s]", objectType, moid)

--- a/pkg/oapi/editable_yaml_test.go
+++ b/pkg/oapi/editable_yaml_test.go
@@ -395,3 +395,54 @@ func TestFilterWritablePropertiesIncludesIdentity(t *testing.T) {
 	// ReadOnly fields (non-identity) must be absent
 	assert.NotContains(t, filtered, "CreateTime")
 }
+
+func TestFilterNestedValueResolvedIdentity(t *testing.T) {
+	meta, err := GetMeta()
+	require.NoError(t, err)
+
+	t.Run("uses _ResolvedIdentity when present", func(t *testing.T) {
+		mo := map[string]any{
+			"ClassId":    "ntp.Policy",
+			"ObjectType": "ntp.Policy",
+			"Moid":       "aabbccddee1122334455aabb",
+			"Name":       "test",
+			"Organization": map[string]any{
+				"ClassId":            "mo.MoRef",
+				"Moid":               "5ddec4226972652d33548943",
+				"ObjectType":         "organization.Organization",
+				"_ResolvedIdentity":  "Name:default",
+			},
+		}
+		filtered, err := FilterWritableProperties(mo, "ntp.Policy")
+		require.NoError(t, err)
+		assert.Equal(t, "MoRef:organization.Organization[Name:default]", filtered["Organization"])
+	})
+
+	t.Run("falls back to Moid when _ResolvedIdentity absent", func(t *testing.T) {
+		mo := map[string]any{
+			"ClassId":    "ntp.Policy",
+			"ObjectType": "ntp.Policy",
+			"Moid":       "aabbccddee1122334455aabb",
+			"Name":       "test",
+			"Organization": map[string]any{
+				"ClassId":    "mo.MoRef",
+				"Moid":       "5ddec4226972652d33548943",
+				"ObjectType": "organization.Organization",
+			},
+		}
+		filtered, err := FilterWritableProperties(mo, "ntp.Policy")
+		require.NoError(t, err)
+		assert.Equal(t, "MoRef:organization.Organization[Moid:5ddec4226972652d33548943]", filtered["Organization"])
+	})
+
+	t.Run("splitBalancedCommas handles nested brackets", func(t *testing.T) {
+		_ = meta // avoid unused var
+		parts := splitBalancedCommas("VlanId:100,EthNetworkPolicy:MoRef:fabric.EthNetworkPolicy[Name:my-policy]")
+		assert.Equal(t, []string{"VlanId:100", "EthNetworkPolicy:MoRef:fabric.EthNetworkPolicy[Name:my-policy]"}, parts)
+	})
+
+	t.Run("splitBalancedCommas handles simple string", func(t *testing.T) {
+		parts := splitBalancedCommas("Name:default,Account:acc1")
+		assert.Equal(t, []string{"Name:default", "Account:acc1"}, parts)
+	})
+}

--- a/pkg/oapi/editable_yaml_test.go
+++ b/pkg/oapi/editable_yaml_test.go
@@ -149,7 +149,7 @@ func TestFilterWritableProperties(t *testing.T) {
 			"Moid":         "6421194f6f62692d31f53ec5",
 			"ClassId":      "fabric.EthNetworkGroupPolicy", // Top-level ClassId preserved
 			"ObjectType":   "fabric.EthNetworkGroupPolicy", // Top-level ObjectType preserved
-			"Organization": "MoRef[Moid:5ddec4226972652d33548943]", // MoRef collapsed to shorthand
+			"Organization": "MoRef:organization.Organization[Moid:5ddec4226972652d33548943]", // MoRef collapsed to shorthand
 			"Description":  "",
 			"Name":         "COMMON-NET-GRP",
 			"Tags":         []any{},
@@ -212,15 +212,15 @@ func TestFilterWritableProperties(t *testing.T) {
 		assert.Equal(t, "test-access-policy", filtered["Name"])
 		assert.NotContains(t, filtered, "CreateTime")
 
-		// MoRefs should be collapsed to shorthand
-		assert.Equal(t, "MoRef[Moid:deadbeef12345678]", filtered["InbandIpPool"])
-		assert.Equal(t, "MoRef[Moid:5ddec4226972652d33548943]", filtered["Organization"])
+		// MoRefs should be collapsed to shorthand with ObjectType
+		assert.Equal(t, "MoRef:ippool.Pool[Moid:deadbeef12345678]", filtered["InbandIpPool"])
+		assert.Equal(t, "MoRef:organization.Organization[Moid:5ddec4226972652d33548943]", filtered["Organization"])
 
-		// Profiles array items should be collapsed
+		// Profiles array items should be collapsed with ObjectType
 		profiles, ok := filtered["Profiles"].([]any)
 		require.True(t, ok)
 		require.Len(t, profiles, 1)
-		assert.Equal(t, "MoRef[Moid:profile001moid]", profiles[0])
+		assert.Equal(t, "MoRef:server.Profile[Moid:profile001moid]", profiles[0])
 
 		// AddressType should not have ClassId/ObjectType (declared type matches)
 		addressType, ok := filtered["AddressType"].(map[string]any)

--- a/pkg/oapi/editable_yaml_test.go
+++ b/pkg/oapi/editable_yaml_test.go
@@ -146,26 +146,97 @@ func TestFilterWritableProperties(t *testing.T) {
 		require.NotNil(t, filtered)
 
 		assert.Equal(t, map[string]any{
-			"Moid":       "6421194f6f62692d31f53ec5",
-			"ClassId":    "fabric.EthNetworkGroupPolicy", // ClassId should be preserved
-			"ObjectType": "fabric.EthNetworkGroupPolicy", // ObjectType should be preserved
-			"Organization": map[string]any{
-				"Moid":       "5ddec4226972652d33548943",
-				"ClassId":    "mo.MoRef",
-				"ObjectType": "organization.Organization",
-			},
-			"Description": "",
-			"Name":        "COMMON-NET-GRP",
-			"Tags":        []any{},
+			"Moid":         "6421194f6f62692d31f53ec5",
+			"ClassId":      "fabric.EthNetworkGroupPolicy", // Top-level ClassId preserved
+			"ObjectType":   "fabric.EthNetworkGroupPolicy", // Top-level ObjectType preserved
+			"Organization": "MoRef[Moid:5ddec4226972652d33548943]", // MoRef collapsed to shorthand
+			"Description":  "",
+			"Name":         "COMMON-NET-GRP",
+			"Tags":         []any{},
 			"VlanSettings": map[string]any{
+				// ClassId/ObjectType omitted because fabric.VlanSettings matches declared type
 				"AllowedVlans": "1-4093",
-				"ClassId":      "fabric.VlanSettings", // Nested ClassId preserved
 				"NativeVlan":   1,
 				"QinqEnabled":  false,
 				"QinqVlan":     2,
-				"ObjectType":   "fabric.VlanSettings",
 			},
 		}, filtered)
+	})
+
+	t.Run("access.Policy MoRef collapsing and ClassId omission", func(t *testing.T) {
+		mo := map[string]any{
+			"ClassId":    "access.Policy",
+			"ObjectType": "access.Policy",
+			"Moid":       "aabbccdd11223344",
+			"Name":       "test-access-policy",
+			"AddressType": map[string]any{
+				"ClassId":    "access.AddressType",
+				"ObjectType": "access.AddressType",
+				"EnableIpV4": true,
+				"EnableIpV6": false,
+			},
+			"ConfigurationType": map[string]any{
+				"ClassId":            "access.ConfigurationType",
+				"ObjectType":         "access.ConfigurationType",
+				"ConfigureInband":    true,
+				"ConfigureOutOfBand": false,
+			},
+			"InbandIpPool": map[string]any{
+				"ClassId":    "mo.MoRef",
+				"ObjectType": "ippool.Pool",
+				"Moid":       "deadbeef12345678",
+			},
+			"Organization": map[string]any{
+				"ClassId":    "mo.MoRef",
+				"ObjectType": "organization.Organization",
+				"Moid":       "5ddec4226972652d33548943",
+			},
+			"Profiles": []any{
+				map[string]any{
+					"ClassId":    "mo.MoRef",
+					"ObjectType": "server.Profile",
+					"Moid":       "profile001moid",
+				},
+			},
+			"CreateTime": "2024-01-01T00:00:00Z", // Read-only, should be filtered
+		}
+
+		filtered, err := FilterWritableProperties(mo, "access.Policy")
+		require.NoError(t, err)
+		require.NotNil(t, filtered)
+
+		// Top-level ClassId/ObjectType preserved
+		assert.Equal(t, "access.Policy", filtered["ClassId"])
+		assert.Equal(t, "access.Policy", filtered["ObjectType"])
+		assert.Equal(t, "aabbccdd11223344", filtered["Moid"])
+		assert.Equal(t, "test-access-policy", filtered["Name"])
+		assert.NotContains(t, filtered, "CreateTime")
+
+		// MoRefs should be collapsed to shorthand
+		assert.Equal(t, "MoRef[Moid:deadbeef12345678]", filtered["InbandIpPool"])
+		assert.Equal(t, "MoRef[Moid:5ddec4226972652d33548943]", filtered["Organization"])
+
+		// Profiles array items should be collapsed
+		profiles, ok := filtered["Profiles"].([]any)
+		require.True(t, ok)
+		require.Len(t, profiles, 1)
+		assert.Equal(t, "MoRef[Moid:profile001moid]", profiles[0])
+
+		// AddressType should not have ClassId/ObjectType (declared type matches)
+		addressType, ok := filtered["AddressType"].(map[string]any)
+		require.True(t, ok)
+		assert.NotContains(t, addressType, "ClassId")
+		assert.NotContains(t, addressType, "ObjectType")
+		assert.Equal(t, true, addressType["EnableIpV4"])
+		assert.Equal(t, false, addressType["EnableIpV6"])
+
+		// ConfigurationType should not have ClassId/ObjectType (declared type matches)
+		configType, ok := filtered["ConfigurationType"].(map[string]any)
+		require.True(t, ok)
+		assert.NotContains(t, configType, "ClassId")
+		assert.NotContains(t, configType, "ObjectType")
+		assert.Equal(t, true, configType["ConfigureInband"])
+		assert.Equal(t, false, configType["ConfigureOutOfBand"])
 	})
 
 	t.Run("returns error for invalid classId", func(t *testing.T) {

--- a/pkg/oapi/editable_yaml_test.go
+++ b/pkg/oapi/editable_yaml_test.go
@@ -265,6 +265,79 @@ func TestFilterWritableProperties(t *testing.T) {
 	})
 }
 
+func TestStripEmptyFields(t *testing.T) {
+	t.Run("removes nil values", func(t *testing.T) {
+		m := map[string]any{"a": nil, "b": "hello"}
+		result := StripEmptyFields(m)
+		assert.NotContains(t, result, "a")
+		assert.Equal(t, "hello", result["b"])
+	})
+
+	t.Run("removes empty strings", func(t *testing.T) {
+		m := map[string]any{"empty": "", "nonempty": "hi"}
+		result := StripEmptyFields(m)
+		assert.NotContains(t, result, "empty")
+		assert.Equal(t, "hi", result["nonempty"])
+	})
+
+	t.Run("removes empty slices", func(t *testing.T) {
+		m := map[string]any{"empty": []any{}, "nonempty": []any{"x"}}
+		result := StripEmptyFields(m)
+		assert.NotContains(t, result, "empty")
+		assert.Contains(t, result, "nonempty")
+	})
+
+	t.Run("removes empty maps", func(t *testing.T) {
+		m := map[string]any{"empty": map[string]any{}, "nonempty": map[string]any{"k": "v"}}
+		result := StripEmptyFields(m)
+		assert.NotContains(t, result, "empty")
+		assert.Contains(t, result, "nonempty")
+	})
+
+	t.Run("removes maps that become empty after recursive stripping", func(t *testing.T) {
+		m := map[string]any{
+			"nested": map[string]any{"inner": ""},
+		}
+		result := StripEmptyFields(m)
+		assert.NotContains(t, result, "nested")
+	})
+
+	t.Run("preserves false boolean values", func(t *testing.T) {
+		m := map[string]any{"flag": false, "other": true}
+		result := StripEmptyFields(m)
+		assert.Equal(t, false, result["flag"])
+		assert.Equal(t, true, result["other"])
+	})
+
+	t.Run("preserves zero integer values", func(t *testing.T) {
+		m := map[string]any{"count": 0, "size": 42}
+		result := StripEmptyFields(m)
+		assert.Equal(t, 0, result["count"])
+		assert.Equal(t, 42, result["size"])
+	})
+
+	t.Run("preserves non-empty nested structures", func(t *testing.T) {
+		m := map[string]any{
+			"nested": map[string]any{"key": "value", "empty": ""},
+		}
+		result := StripEmptyFields(m)
+		nested, ok := result["nested"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "value", nested["key"])
+		assert.NotContains(t, nested, "empty")
+	})
+
+	t.Run("strips empty items from slices", func(t *testing.T) {
+		m := map[string]any{
+			"items": []any{"a", "", "b"},
+		}
+		result := StripEmptyFields(m)
+		items, ok := result["items"].([]any)
+		require.True(t, ok)
+		assert.Equal(t, []any{"a", "b"}, items)
+	})
+}
+
 func TestFormatEditableYAML(t *testing.T) {
 	t.Run("produces valid YAML with only writable properties", func(t *testing.T) {
 		mo := map[string]any{
@@ -276,7 +349,7 @@ func TestFormatEditableYAML(t *testing.T) {
 			"ObjectType": "ntp.Policy",
 		}
 
-		yamlBytes, err := FormatEditableYAML(mo, "ntp.Policy")
+		yamlBytes, err := FormatEditableYAML(mo, "ntp.Policy", false)
 		require.NoError(t, err)
 		require.NotEmpty(t, yamlBytes)
 
@@ -299,7 +372,7 @@ func TestFormatEditableYAML(t *testing.T) {
 
 	t.Run("returns error for invalid classId", func(t *testing.T) {
 		mo := map[string]any{"Name": "test"}
-		yamlBytes, err := FormatEditableYAML(mo, "nonexistent.Class")
+		yamlBytes, err := FormatEditableYAML(mo, "nonexistent.Class", false)
 		assert.Error(t, err)
 		assert.Nil(t, yamlBytes)
 	})
@@ -313,7 +386,7 @@ func TestFormatEditableYAML(t *testing.T) {
 			"ObjectType": "ntp.Policy",
 		}
 
-		yamlBytes, err := FormatEditableYAML(mo, "ntp.Policy")
+		yamlBytes, err := FormatEditableYAML(mo, "ntp.Policy", false)
 		require.NoError(t, err)
 		require.NotEmpty(t, yamlBytes)
 
@@ -334,7 +407,7 @@ func TestFormatEditableYAML(t *testing.T) {
 			"ObjectType": "policy.AbstractConfigProfile",
 		}
 
-		yamlBytes, err := FormatEditableYAML(mo, "policy.AbstractConfigProfile")
+		yamlBytes, err := FormatEditableYAML(mo, "policy.AbstractConfigProfile", false)
 		require.NoError(t, err)
 		require.NotEmpty(t, yamlBytes)
 
@@ -354,7 +427,7 @@ func TestFormatEditableYAML(t *testing.T) {
 			"ObjectType": "ntp.Policy",
 		}
 
-		yamlBytes, err := FormatEditableYAML(mo, "ntp.Policy")
+		yamlBytes, err := FormatEditableYAML(mo, "ntp.Policy", false)
 		require.NoError(t, err)
 		require.NotEmpty(t, yamlBytes)
 
@@ -363,6 +436,45 @@ func TestFormatEditableYAML(t *testing.T) {
 		assert.Contains(t, yamlStr, "Enabled: true")
 		assert.Contains(t, yamlStr, "ClassId: ntp.Policy")
 		assert.Contains(t, yamlStr, "ObjectType: ntp.Policy")
+	})
+
+	t.Run("strips empty fields by default", func(t *testing.T) {
+		mo := map[string]any{
+			"Name":        "test-policy",
+			"Description": "",
+			"Enabled":     true,
+			"NtpServers":  []any{},
+			"Moid":        "12345",
+			"ClassId":     "ntp.Policy",
+			"ObjectType":  "ntp.Policy",
+		}
+
+		yamlBytes, err := FormatEditableYAML(mo, "ntp.Policy", false)
+		require.NoError(t, err)
+		yamlStr := string(yamlBytes)
+		assert.NotContains(t, yamlStr, "Description:")
+		assert.NotContains(t, yamlStr, "NtpServers:")
+		assert.Contains(t, yamlStr, "Name: test-policy")
+		assert.Contains(t, yamlStr, "Enabled: true")
+	})
+
+	t.Run("includes empty fields when includeEmptyFields is true", func(t *testing.T) {
+		mo := map[string]any{
+			"Name":        "test-policy",
+			"Description": "",
+			"Enabled":     true,
+			"NtpServers":  []any{},
+			"Moid":        "12345",
+			"ClassId":     "ntp.Policy",
+			"ObjectType":  "ntp.Policy",
+		}
+
+		yamlBytes, err := FormatEditableYAML(mo, "ntp.Policy", true)
+		require.NoError(t, err)
+		yamlStr := string(yamlBytes)
+		assert.Contains(t, yamlStr, "Description:")
+		assert.Contains(t, yamlStr, "NtpServers:")
+		assert.Contains(t, yamlStr, "Name: test-policy")
 	})
 }
 

--- a/pkg/oapi/editable_yaml_test.go
+++ b/pkg/oapi/editable_yaml_test.go
@@ -147,9 +147,9 @@ func TestFilterWritableProperties(t *testing.T) {
 
 		assert.Equal(t, map[string]any{
 			"Moid":         "6421194f6f62692d31f53ec5",
-			"ClassId":      "fabric.EthNetworkGroupPolicy", // Top-level ClassId preserved
-			"ObjectType":   "fabric.EthNetworkGroupPolicy", // Top-level ObjectType preserved
-			"Organization": "MoRef:organization.Organization[Moid:5ddec4226972652d33548943]", // MoRef collapsed to shorthand
+			"ClassId":      "fabric.EthNetworkGroupPolicy",         // Top-level ClassId preserved
+			"ObjectType":   "fabric.EthNetworkGroupPolicy",         // Top-level ObjectType preserved
+			"Organization": "MoRef[Moid:5ddec4226972652d33548943]", // MoRef collapsed to shorthand
 			"Description":  "",
 			"Name":         "COMMON-NET-GRP",
 			"Tags":         []any{},
@@ -212,11 +212,11 @@ func TestFilterWritableProperties(t *testing.T) {
 		assert.Equal(t, "test-access-policy", filtered["Name"])
 		assert.NotContains(t, filtered, "CreateTime")
 
-		// MoRefs should be collapsed to shorthand with ObjectType
-		assert.Equal(t, "MoRef:ippool.Pool[Moid:deadbeef12345678]", filtered["InbandIpPool"])
-		assert.Equal(t, "MoRef:organization.Organization[Moid:5ddec4226972652d33548943]", filtered["Organization"])
+		// MoRefs should be collapsed to shorthand, omitting ObjectType when it matches declared type
+		assert.Equal(t, "MoRef[Moid:deadbeef12345678]", filtered["InbandIpPool"])
+		assert.Equal(t, "MoRef[Moid:5ddec4226972652d33548943]", filtered["Organization"])
 
-		// Profiles array items should be collapsed with ObjectType
+		// Profiles array items: server.Profile differs from declared policy.AbstractConfigProfile, so type is included
 		profiles, ok := filtered["Profiles"].([]any)
 		require.True(t, ok)
 		require.Len(t, profiles, 1)
@@ -407,15 +407,15 @@ func TestFilterNestedValueResolvedIdentity(t *testing.T) {
 			"Moid":       "aabbccddee1122334455aabb",
 			"Name":       "test",
 			"Organization": map[string]any{
-				"ClassId":            "mo.MoRef",
-				"Moid":               "5ddec4226972652d33548943",
-				"ObjectType":         "organization.Organization",
-				"_ResolvedIdentity":  "Name:default",
+				"ClassId":           "mo.MoRef",
+				"Moid":              "5ddec4226972652d33548943",
+				"ObjectType":        "organization.Organization",
+				"_ResolvedIdentity": "Name:default",
 			},
 		}
 		filtered, err := FilterWritableProperties(mo, "ntp.Policy")
 		require.NoError(t, err)
-		assert.Equal(t, "MoRef:organization.Organization[Name:default]", filtered["Organization"])
+		assert.Equal(t, "MoRef[Name:default]", filtered["Organization"])
 	})
 
 	t.Run("falls back to Moid when _ResolvedIdentity absent", func(t *testing.T) {
@@ -432,7 +432,7 @@ func TestFilterNestedValueResolvedIdentity(t *testing.T) {
 		}
 		filtered, err := FilterWritableProperties(mo, "ntp.Policy")
 		require.NoError(t, err)
-		assert.Equal(t, "MoRef:organization.Organization[Moid:5ddec4226972652d33548943]", filtered["Organization"])
+		assert.Equal(t, "MoRef[Moid:5ddec4226972652d33548943]", filtered["Organization"])
 	})
 
 	t.Run("splitBalancedCommas handles nested brackets", func(t *testing.T) {

--- a/pkg/oapi/meta.go
+++ b/pkg/oapi/meta.go
@@ -202,3 +202,24 @@ func (m *Meta) GetWritableRelationshipNames(classId string) []string {
 	}
 	return names
 }
+
+// GetPropertyOrRelationshipType returns the declared type of a property or relationship
+// for a given class. Checks properties first, then relationships.
+// Returns empty string if the class or property/relationship is not found.
+func (m *Meta) GetPropertyOrRelationshipType(classId, propName string) string {
+	cm := m.GetClassMeta(classId)
+	if cm == nil {
+		return ""
+	}
+	for _, prop := range cm.Properties {
+		if prop.Name == propName {
+			return prop.Type
+		}
+	}
+	for _, rel := range cm.Relationships {
+		if rel.Name == propName {
+			return rel.Type
+		}
+	}
+	return ""
+}

--- a/pkg/oapi/oapi.go
+++ b/pkg/oapi/oapi.go
@@ -62,6 +62,7 @@ func getSchemaProperty(propName string, schema map[string]any) map[string]any {
 }
 
 type MoRef struct {
+	Moid             string // When set, this is a direct Moid reference (no API lookup needed)
 	Filter           string
 	RelationshipType string
 	Organization     string
@@ -83,6 +84,9 @@ func CanonicaliseMoRef(moref string, defaultRelationshipType string) *MoRef {
 	r = regexp.MustCompile(`^[[:xdigit:]]{24}$`)
 	m = r.FindStringSubmatch(moref)
 	if m != nil {
+		if defaultRelationshipType != "" {
+			return &MoRef{Moid: moref}
+		}
 		return nil
 	}
 
@@ -108,6 +112,13 @@ func CanonicaliseMoRef(moref string, defaultRelationshipType string) *MoRef {
 
 	m = r.FindStringSubmatch(moref)
 	if m != nil {
+		// Direct Moid reference with explicit type — no API lookup needed
+		if m[2] == "Moid" && regexp.MustCompile(`^[[:xdigit:]]{24}$`).MatchString(m[3]) {
+			return &MoRef{
+				Moid:             m[3],
+				RelationshipType: canonicaliseRelationshipType(m[1]),
+			}
+		}
 		return &MoRef{
 			Filter:           fmt.Sprintf("%s eq '%s'", m[2], m[3]),
 			RelationshipType: canonicaliseRelationshipType(m[1]),
@@ -117,10 +128,16 @@ func CanonicaliseMoRef(moref string, defaultRelationshipType string) *MoRef {
 	r = regexp.MustCompile(`MoRef\[(\w+):([0-9A-Za-z_\-\.\s]+)\]`)
 
 	m = r.FindStringSubmatch(moref)
-	if m != nil && defaultRelationshipType != "" {
-		return &MoRef{
-			Filter:           fmt.Sprintf("%s eq '%s'", m[1], m[2]),
-			RelationshipType: defaultRelationshipType,
+	if m != nil {
+		// Direct Moid reference without explicit type — no API lookup needed
+		if m[1] == "Moid" && regexp.MustCompile(`^[[:xdigit:]]{24}$`).MatchString(m[2]) {
+			return &MoRef{Moid: m[2]}
+		}
+		if defaultRelationshipType != "" {
+			return &MoRef{
+				Filter:           fmt.Sprintf("%s eq '%s'", m[1], m[2]),
+				RelationshipType: defaultRelationshipType,
+			}
 		}
 	}
 
@@ -131,6 +148,12 @@ func CanonicaliseMoRef(moref string, defaultRelationshipType string) *MoRef {
 			Filter:           fmt.Sprintf("Name eq '%s'", m[2]),
 			RelationshipType: canonicaliseRelationshipType(m[1]),
 		}
+	}
+
+	r = regexp.MustCompile(`^MoRef\[([[:xdigit:]]{24})\]$`)
+	m = r.FindStringSubmatch(moref)
+	if m != nil {
+		return &MoRef{Moid: m[1]}
 	}
 
 	r = regexp.MustCompile(`^MoRef\[([0-9A-Za-z_\-\.\s]+)\]`)

--- a/pkg/oapi/oapi.go
+++ b/pkg/oapi/oapi.go
@@ -61,11 +61,118 @@ func getSchemaProperty(propName string, schema map[string]any) map[string]any {
 	return nil
 }
 
+// IdentityField represents a single field in a multi-field identity-based MoRef.
+type IdentityField struct {
+	Name  string
+	Value string // scalar value, or empty if Ref is set
+	Ref   *MoRef // nested MoRef reference (for relationship fields)
+}
+
 type MoRef struct {
 	Moid             string // When set, this is a direct Moid reference (no API lookup needed)
 	Filter           string
 	RelationshipType string
 	Organization     string
+	IdentityFields   []IdentityField // for multi-field identity-based MoRefs
+}
+
+// splitBalancedCommas splits s at commas that are not inside square brackets.
+func splitBalancedCommas(s string) []string {
+	var parts []string
+	depth := 0
+	start := 0
+	for i, ch := range s {
+		switch ch {
+		case '[':
+			depth++
+		case ']':
+			depth--
+		case ',':
+			if depth == 0 {
+				parts = append(parts, s[start:i])
+				start = i + 1
+			}
+		}
+	}
+	parts = append(parts, s[start:])
+	return parts
+}
+
+// extractBracketedContent extracts the content between the first '[' and its matching ']' in s.
+// Returns content and whether it was found.
+func extractBracketedContent(s string) (string, bool) {
+	start := strings.Index(s, "[")
+	if start == -1 {
+		return "", false
+	}
+	depth := 0
+	for i := start; i < len(s); i++ {
+		switch s[i] {
+		case '[':
+			depth++
+		case ']':
+			depth--
+			if depth == 0 {
+				return s[start+1 : i], true
+			}
+		}
+	}
+	return "", false
+}
+
+// parseMultiFieldMoRef attempts to parse a multi-field identity MoRef of the form
+// MoRef:type[K1:V1,K2:V2,...] where values may themselves be MoRef strings.
+// Returns nil if the string does not match this format.
+func parseMultiFieldMoRef(moref string) *MoRef {
+	// Must start with MoRef: followed by a type
+	r := regexp.MustCompile(`^MoRef:([\w\.]+)\[`)
+	m := r.FindStringSubmatch(moref)
+	if m == nil {
+		return nil
+	}
+	relType := canonicaliseRelationshipType(m[1])
+
+	content, ok := extractBracketedContent(moref)
+	if !ok {
+		return nil
+	}
+
+	// Split content at top-level commas
+	parts := splitBalancedCommas(content)
+
+	// Must have at least 2 parts to be a multi-field MoRef
+	// (single-field cases are handled by the existing regex patterns)
+	if len(parts) < 2 {
+		return nil
+	}
+
+	var fields []IdentityField
+	for _, part := range parts {
+		// Split at first colon to get key:value
+		idx := strings.Index(part, ":")
+		if idx == -1 {
+			return nil // malformed
+		}
+		key := part[:idx]
+		val := part[idx+1:]
+
+		field := IdentityField{Name: key}
+		if strings.HasPrefix(val, "MoRef") {
+			nested := CanonicaliseMoRef(val, "")
+			if nested == nil {
+				return nil
+			}
+			field.Ref = nested
+		} else {
+			field.Value = val
+		}
+		fields = append(fields, field)
+	}
+
+	return &MoRef{
+		RelationshipType: relType,
+		IdentityFields:   fields,
+	}
 }
 
 func canonicaliseRelationshipType(rt string) string {
@@ -106,6 +213,11 @@ func CanonicaliseMoRef(moref string, defaultRelationshipType string) *MoRef {
 			Filter:           m[2],
 			RelationshipType: canonicaliseRelationshipType(m[1]),
 		}
+	}
+
+	// Multi-field identity MoRef: MoRef:type[K1:V1,K2:V2,...] — must be checked before single-field
+	if mf := parseMultiFieldMoRef(moref); mf != nil {
+		return mf
 	}
 
 	r = regexp.MustCompile(`MoRef:([\w\.]+)\[(\w+):([0-9A-Za-z_\-\.\s]+)\]`)

--- a/pkg/oapi/oapi_test.go
+++ b/pkg/oapi/oapi_test.go
@@ -220,7 +220,32 @@ func TestCanonicaliseMoRef(t *testing.T) {
 		{
 			moref:                   "59c84e4a16267c0001c23428",
 			defaultRelationshipType: "organisation.Organisation.Relationship",
+			res:                     &MoRef{Moid: "59c84e4a16267c0001c23428"},
+		},
+		{
+			moref:                   "59c84e4a16267c0001c23428",
+			defaultRelationshipType: "",
 			res:                     nil,
+		},
+		{
+			moref:                   "MoRef[59c84e4a16267c0001c23428]",
+			defaultRelationshipType: "organisation.Organisation.Relationship",
+			res:                     &MoRef{Moid: "59c84e4a16267c0001c23428"},
+		},
+		{
+			moref:                   "MoRef[59c84e4a16267c0001c23428]",
+			defaultRelationshipType: "",
+			res:                     &MoRef{Moid: "59c84e4a16267c0001c23428"},
+		},
+		{
+			moref:                   "MoRef[Moid:59c84e4a16267c0001c23428]",
+			defaultRelationshipType: "organisation.Organisation.Relationship",
+			res:                     &MoRef{Moid: "59c84e4a16267c0001c23428"},
+		},
+		{
+			moref:                   "MoRef[Moid:59c84e4a16267c0001c23428]",
+			defaultRelationshipType: "",
+			res:                     &MoRef{Moid: "59c84e4a16267c0001c23428"},
 		},
 		{
 			moref:                   "MoRef:organization.Organization[default]",
@@ -255,6 +280,21 @@ func TestCanonicaliseMoRef(t *testing.T) {
 				Filter:           "Name eq 'Red Hat Enterprise Linux 7.6'",
 				RelationshipType: "hcl.OperatingSystem",
 			},
+		},
+		{
+			moref:                   "MoRef:server.Profile[Moid:59c84e4a16267c0001c23428]",
+			defaultRelationshipType: "",
+			res:                     &MoRef{Moid: "59c84e4a16267c0001c23428", RelationshipType: "server.Profile"},
+		},
+		{
+			moref:                   "MoRef:OrganizationOrganizationRelationship[Moid:59c84e4a16267c0001c23428]",
+			defaultRelationshipType: "",
+			res:                     &MoRef{Moid: "59c84e4a16267c0001c23428", RelationshipType: "organization.Organization.Relationship"},
+		},
+		{
+			moref:                   "MoRef:organization.Organization[Moid:59c84e4a16267c0001c23428]",
+			defaultRelationshipType: "",
+			res:                     &MoRef{Moid: "59c84e4a16267c0001c23428", RelationshipType: "organization.Organization"},
 		},
 	}
 

--- a/pkg/oapi/oapi_test.go
+++ b/pkg/oapi/oapi_test.go
@@ -296,6 +296,32 @@ func TestCanonicaliseMoRef(t *testing.T) {
 			defaultRelationshipType: "",
 			res:                     &MoRef{Moid: "59c84e4a16267c0001c23428", RelationshipType: "organization.Organization"},
 		},
+		// Multi-field identity MoRefs
+		{
+			moref:                   "MoRef:organization.Organization[Name:default,Account:acc1]",
+			defaultRelationshipType: "",
+			res: &MoRef{
+				RelationshipType: "organization.Organization",
+				IdentityFields: []IdentityField{
+					{Name: "Name", Value: "default"},
+					{Name: "Account", Value: "acc1"},
+				},
+			},
+		},
+		{
+			moref:                   "MoRef:fabric.Vlan[VlanId:100,EthNetworkPolicy:MoRef:fabric.EthNetworkPolicy[Name:my-policy]]",
+			defaultRelationshipType: "",
+			res: &MoRef{
+				RelationshipType: "fabric.Vlan",
+				IdentityFields: []IdentityField{
+					{Name: "VlanId", Value: "100"},
+					{Name: "EthNetworkPolicy", Ref: &MoRef{
+						Filter:           "Name eq 'my-policy'",
+						RelationshipType: "fabric.EthNetworkPolicy",
+					}},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/tests/data/test-direct-moid.yaml.template
+++ b/tests/data/test-direct-moid.yaml.template
@@ -1,0 +1,6 @@
+ClassId: ntp.Policy
+Name: isctl-bats-test-direct-moid-policy
+Organization: "MoRef[Moid:PLACEHOLDER_ORG_MOID]"
+NtpServers:
+  - 1.1.1.1
+  - 2.2.2.2

--- a/tests/direct_moid.bats
+++ b/tests/direct_moid.bats
@@ -1,0 +1,58 @@
+
+TEST_POLICY_NAME=isctl-bats-test-direct-moid-policy
+TEST_ORG_NAME=default
+
+TEST_SECTION="Direct Moid MoRef"
+
+setup_file() {
+    # Get the default org Moid once for all tests
+    ORG_MOID=$(./build/isctl ${ISCTL_OPTIONS} get organization organization --name "${TEST_ORG_NAME}" -o jsonpath='$.Moid')
+    export ORG_MOID
+}
+
+@test "${TEST_SECTION}: create NTP policy with bare hex Moid for Organization" {
+    ./build/isctl ${ISCTL_OPTIONS} create ntp policy \
+        --Name "${TEST_POLICY_NAME}" \
+        --NtpServers 1.1.1.1 \
+        --Organization "${ORG_MOID}"
+}
+
+@test "${TEST_SECTION}: verify policy was created" {
+    ./build/isctl ${ISCTL_OPTIONS} get ntp policy | grep "${TEST_POLICY_NAME}"
+}
+
+@test "${TEST_SECTION}: update policy using MoRef[<hex>] for Organization" {
+    ./build/isctl ${ISCTL_OPTIONS} update ntp policy \
+        moid "$(./build/isctl ${ISCTL_OPTIONS} get ntp policy --name "${TEST_POLICY_NAME}" -o jsonpath='$.Moid')" \
+        --Organization "MoRef[${ORG_MOID}]"
+}
+
+@test "${TEST_SECTION}: update policy using MoRef[Moid:<hex>] for Organization" {
+    ./build/isctl ${ISCTL_OPTIONS} update ntp policy \
+        moid "$(./build/isctl ${ISCTL_OPTIONS} get ntp policy --name "${TEST_POLICY_NAME}" -o jsonpath='$.Moid')" \
+        --Organization "MoRef[Moid:${ORG_MOID}]"
+}
+
+@test "${TEST_SECTION}: apply YAML with MoRef[Moid:<hex>] for Organization" {
+    TMPFILE=$(mktemp /tmp/isctl-test-XXXXXX.yaml)
+    sed "s/PLACEHOLDER_ORG_MOID/${ORG_MOID}/g" tests/data/test-direct-moid.yaml.template > "${TMPFILE}"
+    ./build/isctl ${ISCTL_OPTIONS} apply -f "${TMPFILE}"
+    rm -f "${TMPFILE}"
+}
+
+@test "${TEST_SECTION}: verify policy still exists after apply" {
+    ./build/isctl ${ISCTL_OPTIONS} get ntp policy | grep "${TEST_POLICY_NAME}"
+}
+
+@test "${TEST_SECTION}: update policy using MoRef:organization.Organization[Moid:<hex>] for Organization" {
+    ./build/isctl ${ISCTL_OPTIONS} update ntp policy \
+        moid "$(./build/isctl ${ISCTL_OPTIONS} get ntp policy --name "${TEST_POLICY_NAME}" -o jsonpath='$.Moid')" \
+        --Organization "MoRef:organization.Organization[Moid:${ORG_MOID}]"
+}
+
+teardown_file() {
+    POLICY_MOID=$(./build/isctl ${ISCTL_OPTIONS} get ntp policy --name "${TEST_POLICY_NAME}" -o jsonpath='$.Moid' 2>/dev/null || true)
+    if [ -n "${POLICY_MOID}" ]; then
+        ./build/isctl ${ISCTL_OPTIONS} delete ntp policy moid "${POLICY_MOID}" || true
+    fi
+}

--- a/tests/ntp_policy.bats
+++ b/tests/ntp_policy.bats
@@ -204,8 +204,8 @@ TEST_SECTION="NTP Policy CRUD"
     assert_success
 
     # Organization should be emitted as a Name-based MoRef, not Moid-based
-    assert_line --partial "Organization: MoRef:organization.Organization[Name:"
-    refute_line --partial "Organization: MoRef:organization.Organization[Moid:"
+    assert_line --partial "Organization: MoRef[Name:"
+    refute_line --partial "Organization: MoRef[Moid:"
 }
 
 @test "${TEST_SECTION}: without --readable-morefs yaml-editable uses Moid-based MoRef" {
@@ -213,8 +213,8 @@ TEST_SECTION="NTP Policy CRUD"
     assert_success
 
     # Organization should use the Moid-based form by default
-    assert_line --partial "Organization: MoRef:organization.Organization[Moid:"
-    refute_line --partial "Organization: MoRef:organization.Organization[Name:"
+    assert_line --partial "Organization: MoRef[Moid:"
+    refute_line --partial "Organization: MoRef[Name:"
 }
 
 @test "${TEST_SECTION}: --readable-morefs does not crash in default output" {

--- a/tests/ntp_policy.bats
+++ b/tests/ntp_policy.bats
@@ -222,6 +222,45 @@ TEST_SECTION="NTP Policy CRUD"
     assert_success
 }
 
+@test "${TEST_SECTION}: default output for single result uses yaml-editable format" {
+    run ./build/isctl ${ISCTL_OPTIONS} get ntp policy --name "${TEST_NTP_POLICY_NAME}"
+    assert_success
+
+    # Should contain yaml-editable style fields
+    assert_line --partial "ClassId:"
+    assert_line --partial "ObjectType:"
+    assert_line --partial "Moid:"
+    assert_line --partial "Name:"
+
+    # Should NOT contain read-only system fields
+    refute_line --partial "CreateTime:"
+    refute_line --partial "AccountMoid:"
+}
+
+@test "${TEST_SECTION}: default output for single result omits empty fields" {
+    run ./build/isctl ${ISCTL_OPTIONS} get ntp policy --name "${TEST_NTP_POLICY_NAME}"
+    assert_success
+
+    # Description is empty by default - should not appear
+    refute_line --partial "Description:"
+}
+
+@test "${TEST_SECTION}: -o yaml-editable omits empty fields by default" {
+    run ./build/isctl ${ISCTL_OPTIONS} get ntp policy --name "${TEST_NTP_POLICY_NAME}" -o yaml-editable
+    assert_success
+
+    # Description is empty by default - should not appear in output
+    refute_line --partial "Description:"
+}
+
+@test "${TEST_SECTION}: -o yaml-editable --include-empty-fields includes empty fields" {
+    run ./build/isctl ${ISCTL_OPTIONS} get ntp policy --name "${TEST_NTP_POLICY_NAME}" -o yaml-editable --include-empty-fields
+    assert_success
+
+    # Description should appear when --include-empty-fields is set
+    assert_line --partial "Description:"
+}
+
 @test "${TEST_SECTION}: delete NTP policy" {
     ./build/isctl ${ISCTL_OPTIONS} delete ntp policy moid $(./build/isctl ${ISCTL_OPTIONS} get ntp policy --name "${TEST_NTP_POLICY_NAME}" -o jsonpath='$.Moid')
 

--- a/tests/ntp_policy.bats
+++ b/tests/ntp_policy.bats
@@ -191,12 +191,35 @@ TEST_SECTION="NTP Policy CRUD"
 @test "${TEST_SECTION}: -o yaml-editable with filter returns valid YAML" {
     run ./build/isctl ${ISCTL_OPTIONS} get ntp policy --filter "Name eq '${TEST_NTP_POLICY_NAME}'" -o yaml-editable
     assert_success
-    
+
     # Should contain the policy name value
     assert_line --partial "${TEST_NTP_POLICY_NAME}"
-    
+
     # Should NOT contain read-only properties
     refute_line --partial "ModTime:"
+}
+
+@test "${TEST_SECTION}: --readable-morefs uses identity-based MoRef in yaml-editable" {
+    run ./build/isctl ${ISCTL_OPTIONS} get ntp policy --name "${TEST_NTP_POLICY_NAME}" --readable-morefs -o yaml-editable
+    assert_success
+
+    # Organization should be emitted as a Name-based MoRef, not Moid-based
+    assert_line --partial "Organization: MoRef:organization.Organization[Name:"
+    refute_line --partial "Organization: MoRef:organization.Organization[Moid:"
+}
+
+@test "${TEST_SECTION}: without --readable-morefs yaml-editable uses Moid-based MoRef" {
+    run ./build/isctl ${ISCTL_OPTIONS} get ntp policy --name "${TEST_NTP_POLICY_NAME}" -o yaml-editable
+    assert_success
+
+    # Organization should use the Moid-based form by default
+    assert_line --partial "Organization: MoRef:organization.Organization[Moid:"
+    refute_line --partial "Organization: MoRef:organization.Organization[Name:"
+}
+
+@test "${TEST_SECTION}: --readable-morefs does not crash in default output" {
+    run ./build/isctl ${ISCTL_OPTIONS} get ntp policy --name "${TEST_NTP_POLICY_NAME}" --readable-morefs
+    assert_success
 }
 
 @test "${TEST_SECTION}: delete NTP policy" {


### PR DESCRIPTION
## Summary

- Add `MoRef:type[Moid:hex]` syntax for specifying a direct-Moid MoRef with an explicit ObjectType (e.g. `MoRef:server.Profile[Moid:689ea02b77696e3301029b90]`), avoiding an API lookup while still satisfying endpoints that require `ObjectType` in the MoRef
- `yaml-editable` output now emits `MoRef:ObjectType[Moid:hex]` instead of `MoRef[Moid:hex]` when the API response includes an ObjectType — making the exported YAML round-trippable with full type information
- Both CamelCase relationship names (`MoRef:OrganizationOrganizationRelationship[Moid:hex]`) and dot-notation (`MoRef:organization.Organization[Moid:hex]`) are accepted and normalised

